### PR TITLE
feat: add sprite-sheet subsystem with sidebar tab integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/node_modules/**
 dist/**
+logs/
+extras/

--- a/server.cjs
+++ b/server.cjs
@@ -1,0 +1,79 @@
+/**
+ * Mesh2Motion 生产环境静态服务器
+ * 用于 Windows 服务部署（NSSM）
+ * 端口: 20002
+ */
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const PORT = 20002;
+const DIST_DIR = path.join(__dirname, 'dist');
+
+const MIME_TYPES = {
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'application/javascript; charset=utf-8',
+    '.css': 'text/css; charset=utf-8',
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.svg': 'image/svg+xml',
+    '.ico': 'image/x-icon',
+    '.json': 'application/json; charset=utf-8',
+    '.glb': 'model/gltf-binary',
+    '.gltf': 'model/gltf+json',
+    '.wasm': 'application/wasm',
+    '.map': 'application/octet-stream',
+};
+
+const server = http.createServer((req, res) => {
+    let urlPath = req.url.split('?')[0]; // 去掉 query string
+
+    // 默认首页
+    if (urlPath === '/') {
+        urlPath = '/index.html';
+    }
+
+    const filePath = path.join(DIST_DIR, urlPath);
+
+    // 安全检查：防止路径穿越
+    if (!filePath.startsWith(DIST_DIR)) {
+        res.writeHead(403);
+        res.end('Forbidden');
+        return;
+    }
+
+    const ext = path.extname(filePath).toLowerCase();
+
+    fs.readFile(filePath, (err, data) => {
+        if (err) {
+            if (err.code === 'ENOENT') {
+                // SPA fallback: 对于找不到的文件，尝试返回 index.html
+                const fallback = path.join(DIST_DIR, 'index.html');
+                fs.readFile(fallback, (err2, data2) => {
+                    if (err2) {
+                        res.writeHead(404);
+                        res.end('Not Found');
+                        return;
+                    }
+                    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+                    res.end(data2);
+                });
+            } else {
+                res.writeHead(500);
+                res.end('Internal Server Error');
+            }
+            return;
+        }
+
+        const contentType = MIME_TYPES[ext] || 'application/octet-stream';
+        res.writeHead(200, { 'Content-Type': contentType });
+        res.end(data);
+    });
+});
+
+server.listen(PORT, '0.0.0.0', () => {
+    console.log(`[Mesh2Motion] 服务已启动 → http://localhost:${PORT}`);
+    console.log(`[Mesh2Motion] 静态目录: ${DIST_DIR}`);
+});

--- a/src/Mesh2MotionEngine.ts
+++ b/src/Mesh2MotionEngine.ts
@@ -144,6 +144,16 @@ export class Mesh2MotionEngine {
     return this.scene
   }
 
+  /**
+   * The main WebGLRenderer is private to the engine. Expose a read-only
+   * view of it so the sprite-sheet preview can spin up a second renderer
+   * that shares the same scene (used as a "mini viewport" of the model
+   * rendered from the sprite sheet's pitch + distance).
+   */
+  public get_camera_target (): Vector3 {
+    return this.scene_environment.get_camera_target()
+  }
+
   /* Add this attribute to an HTML element to give it a tooltip */
   private setup_tooltips (): void {
     tippy('[data-tippy-content]', { theme: 'mesh2motion' })
@@ -162,6 +172,18 @@ export class Mesh2MotionEngine {
 
   public set_camera_position (position: Vector3): void {
     this.scene_environment.set_camera_position(position)
+  }
+
+  /** Read the main scene camera's current pitch (degrees) and distance from
+   *  the OrbitControls target. Returns null if the orbit controls aren't ready. */
+  public get_camera_angles (): { pitch_degrees: number, distance: number } | null {
+    return this.scene_environment.get_camera_angles()
+  }
+
+  /** Apply a pitch (degrees) + distance to the main scene camera, keeping its
+   *  current horizontal azimuth. */
+  public set_camera_angles (pitch_degrees: number, distance: number): void {
+    this.scene_environment.set_camera_angles(pitch_degrees, distance)
   }
 
   /** Trigger a gentle camera shake transition effect. */

--- a/src/Mesh2MotionEngine.ts
+++ b/src/Mesh2MotionEngine.ts
@@ -5,6 +5,7 @@ import type { CustomViewHelper } from './lib/CustomViewHelper.ts'
 import tippy from 'tippy.js'
 import './environment.js'
 import 'tippy.js/dist/tippy.css' // optional for styling
+import './lib/sprite-sheet/sprite-sheet.css'
 
 import { Utility } from './lib/Utilities.ts'
 import { Generators } from './lib/Generators.ts'

--- a/src/create.html
+++ b/src/create.html
@@ -6,7 +6,8 @@
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  </head>
+      <link rel="stylesheet" href="./lib/sprite-sheet/sprite-sheet.css" crossorigin="anonymous" />
+</head>
   <body style="margin: 0">
     <script type="module" src="./CustomModelUploadBootstrap.ts"></script>
     <link href="./styles.css" rel="stylesheet" crossorigin="anonymous" />
@@ -320,13 +321,8 @@
                 <!-- Filter textbox for animations -->
                 <span style="position: relative; flex: 1;">
                     <input type="text" id="animation-filter" placeholder="Filter">
+                    <div id="animation-listing-count">0</div>
                 </span>
-            </div>
-
-            <!-- Select all / Deselect all button and animation count -->
-            <div id="toggle-select-all-container">
-                <button id="toggle-select-all-animations" class="secondary-button">Select All</button>
-                <div id="animation-listing-count" style="white-space: nowrap;">0 animations</div>
             </div>
 
 
@@ -339,7 +335,7 @@
 
             <!-- javascript will populate this item with animations
                          that we get from the animations file(s)  -->
-            <div id="animations-items" class="create-page"></div>
+            <div id="animations-items"></div>
 
             <!-- slider to control arm extension (hide this feature until the base functionality is more stable) -->
             <div id="arm-extension-options">
@@ -511,6 +507,111 @@
                 </div>
               </div>
 
+              
+              <!-- Sprite Sheet Export (popup). Triggered by the in-popup
+                                 Export button (#ss-apply-and-export) below. The main
+                                 Sprite Sheet button was removed — the popup is the
+                                 only entry point. -->
+                            <div class="download-combo">
+                              <div
+                  id="sprite-sheet-settings-popup"
+                  class="download-settings-popup-container"
+                >
+                  <button
+                    id="sprite-sheet-settings-toggle"
+                    class="download-split-toggle"
+                    type="button"
+                    aria-haspopup="dialog"
+                    aria-expanded="false"
+                    aria-controls="sprite-sheet-settings"
+                    data-tippy-content="Sprite sheet settings"
+                    aria-label="Open sprite sheet settings"
+                  >
+                    <img src="images/icons/arrow-dropdown.svg" alt="dropdown" width="16" height="16" />
+                  </button>
+
+                  <div
+                    id="sprite-sheet-settings"
+                    class="sprite-sheet-settings-panel"
+                    role="dialog"
+                    aria-label="Sprite sheet settings"
+                    hidden
+                  >
+                    <span class="settings-section-label">Sampling</span>
+                    <div class="sprite-sheet-setting-row">
+                      <label for="ss-sample-every">Sample every</label>
+                      <input type="number" id="ss-sample-every" min="1" max="60" value="1" />
+                      <span style="font-size:12px;color:var(--text-alternate)">frame(s)</span>
+                    </div>
+
+                    <hr />
+
+                    <span class="settings-section-label">Camera</span>
+                    <div class="sprite-sheet-setting-row">
+                      <label for="ss-pitch-angle">Pitch (°)</label>
+                      <input type="number" id="ss-pitch-angle" min="-80" max="80" step="1" value="60" class="ss-sync-input" />
+                      <button id="ss-pitch-apply" class="ss-sync-btn" data-tippy-content="Apply pitch to scene camera" aria-label="Apply pitch to scene camera" type="button">⤓</button>
+                      <button id="ss-pitch-read" class="ss-sync-btn" data-tippy-content="Read pitch from scene camera" aria-label="Read pitch from scene camera" type="button">⤒</button>
+                    </div>
+                    <div class="sprite-sheet-setting-row">
+                      <label for="ss-camera-distance">Distance</label>
+                      <input type="number" id="ss-camera-distance" min="1" max="50" step="0.5" value="10" class="ss-sync-input" />
+                      <button id="ss-distance-apply" class="ss-sync-btn" data-tippy-content="Apply distance to scene camera" aria-label="Apply distance to scene camera" type="button">⤓</button>
+                      <button id="ss-distance-read" class="ss-sync-btn" data-tippy-content="Read distance from scene camera" aria-label="Read distance from scene camera" type="button">⤒</button>
+                    </div>
+
+                    <hr />
+
+                    <span class="settings-section-label">Canvas &amp; Frame</span>
+                                        <div class="sprite-sheet-setting-row">
+                                          <label for="ss-canvas-width">Canvas width (px)</label>
+                                          <input type="number" id="ss-canvas-width" min="64" max="4096" step="32" value="1024" />
+                                        </div>
+                                        <div class="sprite-sheet-setting-row">
+                                          <label for="ss-canvas-height">Canvas height (px)</label>
+                                          <input type="number" id="ss-canvas-height" min="64" max="4096" step="32" value="1024" />
+                                        </div>
+                                        <div class="sprite-sheet-setting-row">
+                                          <label for="ss-frame-width">Frame width (px)</label>
+                                          <input type="number" id="ss-frame-width" min="16" max="2048" step="8" value="128" />
+                                        </div>
+                                        <div class="sprite-sheet-setting-row">
+                                          <label for="ss-frame-height">Frame height (px)</label>
+                                          <input type="number" id="ss-frame-height" min="16" max="2048" step="8" value="128" />
+                                        </div>
+                                        <div class="sprite-sheet-setting-row">
+                                          <label for="ss-padding">Padding (px)</label>
+                                          <input type="number" id="ss-padding" min="0" max="128" value="2" />
+                                        </div>
+                                        <div class="sprite-sheet-setting-row">
+                                          <label class="ss-toggle-label" for="ss-silhouette">
+                                            <input type="checkbox" id="ss-silhouette" />
+                                            <span>Silhouette (black on green)</span>
+                                          </label>
+                                        </div>
+                                        <div class="sprite-sheet-setting-row ss-preview-row">
+                                          <canvas id="ss-preview-canvas" class="ss-preview-canvas" width="160" height="160"></canvas>
+                                        </div>
+
+                    <hr />
+
+                    <span class="settings-section-label">Directions</span>
+                    <div id="ss-direction-grid" class="sprite-sheet-direction-grid">
+                    </div>
+
+                    <hr />
+
+                    <div class="sprite-sheet-actions-row">
+                      <button id="ss-select-all" type="button">All</button>
+                      <button id="ss-select-cardinal" type="button">Cardinal</button>
+                      <button id="ss-select-diagonal" type="button">Diagonal</button>
+                      <button id="ss-reset-defaults" type="button">Defaults</button>
+                      <button id="ss-apply-and-export" type="button" class="primary-action">Export</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <a id="download-hidden-link" href="#" style="display: none"></a>
             </div>
           </div>
@@ -525,6 +626,6 @@
     <div id="view-control-hitbox"></div>
 
     <!-- build version information-->
-    <span id="build-version"></span>
-  </body>
-</html>
+        <span id="build-version"></span>
+      </body>
+    </html>

--- a/src/create.html
+++ b/src/create.html
@@ -6,7 +6,6 @@
     <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico" />
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <link rel="stylesheet" href="./lib/sprite-sheet/sprite-sheet.css" crossorigin="anonymous" />
 </head>
   <body style="margin: 0">
     <script type="module" src="./CustomModelUploadBootstrap.ts"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
     <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="./lib/sprite-sheet/sprite-sheet.css" crossorigin="anonymous" />
 </head>
 <body style="margin: 0">
     <!-- Script files-->

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
     <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico" />
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./lib/sprite-sheet/sprite-sheet.css" crossorigin="anonymous" />
 </head>
 <body style="margin: 0">
     <!-- Script files-->
@@ -45,7 +46,7 @@
     <div id="tool-panel">
         <!-- create a radio button group. There are two options. Move Skeleton, Rotate Mesh -->
         <div id="tool-selection-group">
-           
+
                 <!-- <div style="margin-bottom: 1rem; padding: 0;">
 
                     <span id="current-step-label"></span>
@@ -90,22 +91,70 @@
                     <div id="model-variation-info-details">
                         <span style="display: flex; flex-direction: row; gap: 0.5rem;">
                             <span id="model-variation-info-name"></span>
-                            
+
                         </span>
                         <span>
-                            <span id="model-variation-info-attribution"></span> 
-                            <span id="model-variation-info-license" class="variation-license-chip"></span> 
+                            <span id="model-variation-info-attribution"></span>
+                            <span id="model-variation-info-license" class="variation-license-chip"></span>
                         </span>
-                                             
+
                     </div>
                 </div>
                 <button id="model-variation-button" class="secondary-button">Change</button>
             </div>
 
-    
+
 
             <span id="skinned-step-animation-export-options">
 
+                <!-- =====================================================
+                     Sidebar tab bar: Animations | Sprite Sheet
+                     Replaces the floating-popup "Sprite Sheet settings"
+                     with an in-sidebar dedicated tab page, so the
+                     ever-growing settings UI (Sampling / Camera /
+                     Frame Size / Directions) no longer overflows a
+                     tiny floating dialog.
+                     ===================================================== -->
+                <div
+                  id="sidebar-tab-bar"
+                  class="sidebar-tab-bar"
+                  role="tablist"
+                  aria-label="Sidebar view"
+                >
+                  <button
+                    type="button"
+                    id="sidebar-tab-animations"
+                    class="sidebar-tab active"
+                    role="tab"
+                    aria-selected="true"
+                    aria-controls="sidebar-panel-animations"
+                    data-tab-target="animations"
+                  >
+                    <img src="images/icons/list.svg" alt="" width="14" height="14" />
+                    <span>Animations</span>
+                  </button>
+                  <button
+                    type="button"
+                    id="sidebar-tab-sprite-sheet"
+                    class="sidebar-tab"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="sidebar-panel-sprite-sheet"
+                    data-tab-target="sprite-sheet"
+                  >
+                    <img src="images/icons/grid.svg" alt="" width="14" height="14" />
+                    <span>Sprite Sheet</span>
+                  </button>
+                </div>
+
+                <!-- ===== Tab panel: Animations ===== -->
+                <section
+                  id="sidebar-panel-animations"
+                  class="sidebar-tab-panel active"
+                  role="tabpanel"
+                  aria-labelledby="sidebar-tab-animations"
+                  data-tab-panel="animations"
+                >
                 <div id="animations-listing">
 
                     <!-- Filter textbox and tab switcher side by side -->
@@ -123,15 +172,20 @@
                         <!-- Filter textbox for animations -->
                         <span style="position: relative; flex: 1;">
                             <input type="text" id="animation-filter" placeholder="Filter">
+                            <div id="animation-listing-count">0</div>
                         </span>
                     </div>
-                    
-                    <!-- Select all / Deselect all button and animation count -->
-                    <div id="toggle-select-all-container">
-                        <button id="toggle-select-all-animations" class="secondary-button">Select All</button>
-                        <div id="animation-listing-count" style="white-space: nowrap;">0 animations</div>
+
+                    <!-- All checkbox: when unchecked (default) hides animations
+                         without a preview video; when checked shows everything -->
+                    <div style="display: flex; align-items: center; gap: 6px; padding: 4px 0;">
+                        <label class="styled-checkbox" style="display: inline-flex; align-items: center; gap: 4px; cursor: pointer; font-size: 12px;">
+                            <input type="checkbox" id="animation-show-all">
+                            <span>All</span>
+                        </label>
+                        <span style="font-size: 11px; color: var(--text-alternate, #aaa);">Show animations without preview</span>
                     </div>
-                    
+
 
                     <!-- loading progress when animations start getting larger. -->
                     <div id="animation-progress-loader-container" style="display: none">
@@ -139,17 +193,18 @@
                         <div id="loading-progress-bar"></div>
                         <div id="current-file-progress-bar"></div>
                     </div>
-       
-        
+
+
+
                     <!-- javascript will populate this item with animations
                          that we get from the animations file(s)  -->
-                    <div id="animations-items"> </div> 
+                    <div id="animations-items"> </div>
 
-       
-       
+
+
 
                     <div class="download-actions-row">
-                        
+
                         <!-- testing the mirroring options. Hide this for now until we get a better implementation for per animations -->
                         <div style="display: none" class="styled-checkbox icon-toggle">
                             <input type="checkbox" id="mirror-animations-checkbox" name="mirror-animations" value="true" style="display:none;">
@@ -203,13 +258,131 @@
                         <a id="download-hidden-link" href="#" style="display:none"></a>
                     </div>
 
-
-       
                 </div>
-        
-               
-            </span>
+                </section>
 
+                <!-- ===== Tab panel: Sprite Sheet =====
+                     Dedicated sidebar page for everything sprite-sheet
+                     related: live preview, sampling, camera, frame size,
+                     directions, presets, and the big Export button.
+                     Always inline in the sidebar (no more floating popup,
+                     no more cramped 380×612 panel). Tab bar above toggles
+                     which panel is visible. -->
+                <section
+                  id="sidebar-panel-sprite-sheet"
+                  class="sidebar-tab-panel"
+                  role="tabpanel"
+                  aria-labelledby="sidebar-tab-sprite-sheet"
+                  data-tab-panel="sprite-sheet"
+                  hidden
+                >
+                  <div
+                    id="sprite-sheet-settings"
+                    class="sprite-sheet-settings-panel"
+                  >
+                    <!-- Preview: live canvas. Always on — settings changes
+                         (pitch / distance / frame size) are reflected in
+                         the preview automatically. The Camera section's
+                         Apply/Read buttons sync to the MAIN 3D viewport,
+                         which is a separate thing. -->
+                    <div class="ss-section">
+                      <span class="settings-section-label">Preview</span>
+                      <div class="ss-preview-row">
+                        <canvas id="ss-preview-canvas" class="ss-preview-canvas" width="160" height="160"></canvas>
+                      </div>
+                    </div>
+
+                    <hr />
+
+                    <div class="ss-section">
+                      <span class="settings-section-label">Sampling</span>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-sample-every">Sample every</label>
+                        <input type="number" id="ss-sample-every" min="1" max="60" value="1" />
+                        <span style="font-size:12px;color:var(--text-alternate)">frame(s)</span>
+                      </div>
+                    </div>
+
+                    <hr />
+
+                    <div class="ss-section">
+                      <span class="settings-section-label">Camera</span>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-pitch-angle">Pitch (°)</label>
+                        <input type="number" id="ss-pitch-angle" min="-80" max="80" step="1" value="60" class="ss-sync-input" />
+                        <button id="ss-pitch-apply" class="ss-sync-btn" data-tippy-content="Apply pitch to main 3D camera" aria-label="Apply pitch to main 3D camera" type="button">⤓</button>
+                        <button id="ss-pitch-read" class="ss-sync-btn" data-tippy-content="Read pitch from main 3D camera" aria-label="Read pitch from main 3D camera" type="button">⤒</button>
+                      </div>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-camera-distance">Distance</label>
+                        <input type="number" id="ss-camera-distance" min="1" max="50" step="0.5" value="10" class="ss-sync-input" />
+                        <button id="ss-distance-apply" class="ss-sync-btn" data-tippy-content="Apply distance to main 3D camera" aria-label="Apply distance to main 3D camera" type="button">⤓</button>
+                        <button id="ss-distance-read" class="ss-sync-btn" data-tippy-content="Read distance from main 3D camera" aria-label="Read distance from main 3D camera" type="button">⤒</button>
+                      </div>
+                    </div>
+
+                    <hr />
+
+                    <div class="ss-section">
+                      <span class="settings-section-label">Canvas &amp; Frame</span>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-canvas-width">Canvas width (px)</label>
+                        <input type="number" id="ss-canvas-width" min="64" max="4096" step="32" value="1024" />
+                      </div>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-canvas-height">Canvas height (px)</label>
+                        <input type="number" id="ss-canvas-height" min="64" max="4096" step="32" value="1024" />
+                      </div>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-frame-width">Frame width (px)</label>
+                        <input type="number" id="ss-frame-width" min="16" max="2048" step="8" value="128" />
+                      </div>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-frame-height">Frame height (px)</label>
+                        <input type="number" id="ss-frame-height" min="16" max="2048" step="8" value="128" />
+                      </div>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-padding">Padding (px)</label>
+                        <input type="number" id="ss-padding" min="0" max="128" value="0" />
+                      </div>
+                      <div class="sprite-sheet-setting-row">
+                        <label class="ss-toggle-label" for="ss-silhouette">
+                          <input type="checkbox" id="ss-silhouette" />
+                          <span>Silhouette (black on background)</span>
+                        </label>
+                      </div>
+                      <div class="sprite-sheet-setting-row">
+                        <label for="ss-background-color">Background color</label>
+                        <input type="color" id="ss-background-color" value="#00ff00" />
+                      </div>
+                      <div class="sprite-sheet-setting-row">
+                        <label class="ss-toggle-label" for="ss-one-row-per-direction">
+                          <input type="checkbox" id="ss-one-row-per-direction" />
+                          <span>1 row per direction</span>
+                        </label>
+                      </div>
+                    </div>
+
+                    <hr />
+
+                    <div class="ss-section">
+                      <span class="settings-section-label">Directions</span>
+                      <div id="ss-direction-grid" class="sprite-sheet-direction-grid">
+                      </div>
+                    </div>
+
+                    <hr />
+
+                    <div class="sprite-sheet-actions-row">
+                      <button id="ss-select-all" type="button">All</button>
+                      <button id="ss-select-cardinal" type="button">Cardinal</button>
+                      <button id="ss-select-diagonal" type="button">Diagonal</button>
+                      <button id="ss-reset-defaults" type="button">Defaults</button>
+                      <button id="ss-apply-and-export" type="button" class="primary-action">Export</button>
+                    </div>
+                  </div>
+                </section>
+            </span>
 
         </div>
 
@@ -235,11 +408,11 @@
                     <div id="variation-loading-container" class="variation-loading-container" style="display: none">
                         <div class="variation-loading-track">
                             <span id="variation-loading-text" class="variation-loading-text">Loading model…</span>
-                            <div id="variation-loading-bar" class="variation-loading-bar"></div>
+                            <div class="variation-loading-bar"></div>
                         </div>
-                        
+
                     </div>
-                    <div class="variation-dialog-buttons">
+                    <div class="modal-dialog-buttons">
                         <button id="variation-cancel-button" class="secondary-button">Cancel</button>
                         <button id="variation-confirm-button" disabled>Replace Model</button>
                     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -175,16 +175,6 @@
                         </span>
                     </div>
 
-                    <!-- All checkbox: when unchecked (default) hides animations
-                         without a preview video; when checked shows everything -->
-                    <div style="display: flex; align-items: center; gap: 6px; padding: 4px 0;">
-                        <label class="styled-checkbox" style="display: inline-flex; align-items: center; gap: 4px; cursor: pointer; font-size: 12px;">
-                            <input type="checkbox" id="animation-show-all">
-                            <span>All</span>
-                        </label>
-                        <span style="font-size: 11px; color: var(--text-alternate, #aaa);">Show animations without preview</span>
-                    </div>
-
 
                     <!-- loading progress when animations start getting larger. -->
                     <div id="animation-progress-loader-container" style="display: none">

--- a/src/lib/EventListeners.ts
+++ b/src/lib/EventListeners.ts
@@ -5,6 +5,7 @@ import { TransformSpace } from './enums/TransformSpace'
 import { Utility } from './Utilities'
 import { ModelCleanupUtility } from './processes/load-model/ModelCleanupUtility'
 import { DownloadSuccessDialog } from './components/download-success/DownloadSuccessDialog'
+import { SpriteSheetUI } from './sprite-sheet/SpriteSheetUI.ts'
 import { type Bone } from 'three'
 
 export class EventListeners {
@@ -248,6 +249,40 @@ export class EventListeners {
       )
       new DownloadSuccessDialog().show()
     })
+    // ---- Sprite Sheet Export (setup once at class construction time) ----
+    const sprite_sheet_ui = new SpriteSheetUI(this.bootstrap)
+
+        // The Export button inside the Sprite Sheet panel dispatches a custom
+        // event on its own DOM node. We listen for it on that node directly —
+        // the sidebar tab is the only place the export can be triggered from
+        // now (the main bottom-row button was removed; exporting means the
+        // user wants the full settings UI).
+        this.bootstrap.ui.dom_ss_apply_and_export?.addEventListener('click', () => {
+          sprite_sheet_ui.read_ui_into_settings()
+          sprite_sheet_ui.save_settings()
+          // Re-dispatch on the export button (legacy contract — EventListeners
+          // listens for the same custom event there).
+          const export_button = this.bootstrap.ui.dom_ss_apply_and_export
+          export_button?.dispatchEvent(new CustomEvent('sprite-sheet-start-export', { bubbles: true }))
+        })
+
+        this.bootstrap.ui.dom_ss_apply_and_export?.addEventListener('sprite-sheet-start-export', async () => {
+          const anim_step = this.bootstrap.animations_listing_step
+          const clips = anim_step.animation_clips()
+          const current_idx = anim_step.current_animation_index()
+
+          if (clips.length === 0 || current_idx < 0 || current_idx >= clips.length) {
+            console.warn('SpriteSheet: no animation selected')
+            return
+          }
+
+          const clip = clips[current_idx]
+          const meshes = anim_step.active_skinned_meshes()
+          const mixer = anim_step.mixer()
+          const scene = this.bootstrap.get_scene()
+
+          await sprite_sheet_ui.do_export(meshes, clip, mixer, scene)
+        })
 
     // going back to edit skeleton step after skinning
     // this will do a lot of resetting

--- a/src/lib/SceneEnvironmentManager.ts
+++ b/src/lib/SceneEnvironmentManager.ts
@@ -95,6 +95,68 @@ export class SceneEnvironmentManager {
     this.controls?.update()
   }
 
+  /**
+   * The point the OrbitControls orbit around (usually the model origin).
+   * Returned as a fresh Vector3 so callers can mutate it safely. Falls back
+   * to the world origin if controls aren't ready yet.
+   */
+  public get_camera_target (): Vector3 {
+    if (this.controls === undefined) {
+      return new THREE.Vector3(0, 0.9, 0)
+    }
+    return this.controls.target.clone()
+  }
+
+  /**
+   * Read the current camera's pitch and distance from the OrbitControls target.
+   * Returns degrees (-90..+90) and world units.
+   */
+  public get_camera_angles (): { pitch_degrees: number, distance: number } | null {
+    if (this.controls === undefined) return null
+    const target = this.controls.target
+    const dx = this.camera.position.x - target.x
+    const dy = this.camera.position.y - target.y
+    const dz = this.camera.position.z - target.z
+    const distance = Math.sqrt(dx * dx + dy * dy + dz * dz)
+    // elevation = atan2(vertical, horizontal) → 0 horizontal, +90 looking from top
+    const horizontal = Math.sqrt(dx * dx + dz * dz)
+    const pitch_rad = Math.atan2(dy, horizontal)
+    const pitch_degrees = (pitch_rad * 180) / Math.PI
+    return { pitch_degrees, distance }
+  }
+
+  /**
+   * Apply a pitch (degrees) + distance to the main camera, keeping its current
+   * horizontal azimuth (orbit angle around target). The camera remains looking
+   * at the OrbitControls target.
+   */
+  public set_camera_angles (pitch_degrees: number, distance: number): void {
+    if (this.controls === undefined) return
+    const target = this.controls.target
+    const dx = this.camera.position.x - target.x
+    const dz = this.camera.position.z - target.z
+    const current_horizontal = Math.sqrt(dx * dx + dz * dz)
+    if (current_horizontal < 1e-6) {
+      // No horizontal component (camera directly above/below target): keep the
+      // existing camera position to avoid snapping to azimuth 0.
+      console.warn('SceneEnvironmentManager.set_camera_angles: camera is on the target vertical axis; azimuth would be ambiguous, skipping apply')
+      return
+    }
+    const azimuth = Math.atan2(dx, dz)
+    const pitch_rad = (pitch_degrees * Math.PI) / 180
+    const horizontal = distance * Math.cos(pitch_rad)
+    const vertical = distance * Math.sin(pitch_rad)
+    this.camera.position.set(
+      target.x + horizontal * Math.sin(azimuth),
+      target.y + vertical,
+      target.z + horizontal * Math.cos(azimuth)
+    )
+    // Honor the configured zoom limits.
+    this.controls.minDistance = Math.min(this.controls.minDistance, distance)
+    this.controls.maxDistance = Math.max(this.controls.maxDistance, distance)
+    this.controls.update()
+  }
+
   public frame_change (): void {
     if (this.controls === undefined) {
       return

--- a/src/lib/UI.ts
+++ b/src/lib/UI.ts
@@ -109,6 +109,44 @@ export class UI {
   dom_floor_grid_toggle: HTMLInputElement | null = null
   dom_solid_background_toggle: HTMLInputElement | null = null
 
+  // Sprite sheet: settings panel lives in the sidebar tab now. The
+  // only export trigger is the in-panel "Export" button (#ss-apply-and-export);
+  // dispatch_event routes through that button.
+  dom_sprite_sheet_settings_panel: HTMLElement | null = null
+
+  // Sidebar tab bar (Animations / Sprite Sheet).
+  dom_sidebar_tab_bar: HTMLElement | null = null
+  dom_sidebar_panel_animations: HTMLElement | null = null
+  dom_sidebar_panel_sprite_sheet: HTMLElement | null = null
+
+  // Sprite sheet panel inputs / buttons. The live preview canvas is
+  // always on (no start/stop button); settings changes flow through
+  // preview via the render loop. Camera section keeps its Apply/Read
+  // buttons because those sync to the main 3D viewport, not preview.
+  dom_ss_sample_every: HTMLInputElement | null = null
+  dom_ss_canvas_width: HTMLInputElement | null = null
+  dom_ss_canvas_height: HTMLInputElement | null = null
+  dom_ss_frame_width: HTMLInputElement | null = null
+  dom_ss_frame_height: HTMLInputElement | null = null
+  dom_ss_padding: HTMLInputElement | null = null
+  dom_ss_pitch_angle: HTMLInputElement | null = null
+  dom_ss_camera_distance: HTMLInputElement | null = null
+  dom_ss_pitch_apply: HTMLButtonElement | null = null
+  dom_ss_pitch_read: HTMLButtonElement | null = null
+  dom_ss_distance_apply: HTMLButtonElement | null = null
+  dom_ss_distance_read: HTMLButtonElement | null = null
+  dom_ss_silhouette: HTMLInputElement | null = null
+  dom_ss_background_color: HTMLInputElement | null = null
+  dom_ss_one_row_per_direction: HTMLInputElement | null = null
+  dom_ss_preview_canvas: HTMLCanvasElement | null = null
+  dom_ss_direction_grid: HTMLElement | null = null
+  dom_ss_select_all: HTMLButtonElement | null = null
+  dom_ss_select_cardinal: HTMLButtonElement | null = null
+  dom_ss_select_diagonal: HTMLButtonElement | null = null
+  dom_ss_reset_defaults: HTMLButtonElement | null = null
+  dom_ss_apply_and_export: HTMLButtonElement | null = null
+
+
   private constructor () {
     this.initialize_dom_elements()
   }
@@ -230,6 +268,39 @@ export class UI {
     this.dom_turntable_speed_input = document.querySelector('#turntable-speed-input')
     this.dom_floor_grid_toggle = document.querySelector('#floor-grid-toggle')
     this.dom_solid_background_toggle = document.querySelector('#solid-background-toggle')
+
+    // Sprite sheet settings panel (the in-sidebar tab body).
+    this.dom_sprite_sheet_settings_panel = document.querySelector('#sprite-sheet-settings')
+
+    // Sidebar tab bar (Animations / Sprite Sheet). Switching between
+    // these is driven by SpriteSheetUI via the .sidebar-tab elements.
+    this.dom_sidebar_tab_bar = document.querySelector('#sidebar-tab-bar')
+    this.dom_sidebar_panel_animations = document.querySelector('#sidebar-panel-animations')
+    this.dom_sidebar_panel_sprite_sheet = document.querySelector('#sidebar-panel-sprite-sheet')
+
+    this.dom_ss_sample_every = document.querySelector('#ss-sample-every')
+    this.dom_ss_canvas_width = document.querySelector('#ss-canvas-width')
+    this.dom_ss_canvas_height = document.querySelector('#ss-canvas-height')
+    this.dom_ss_frame_width = document.querySelector('#ss-frame-width')
+    this.dom_ss_frame_height = document.querySelector('#ss-frame-height')
+    this.dom_ss_padding = document.querySelector('#ss-padding')
+    this.dom_ss_pitch_angle = document.querySelector('#ss-pitch-angle')
+    this.dom_ss_camera_distance = document.querySelector('#ss-camera-distance')
+    this.dom_ss_pitch_apply = document.querySelector('#ss-pitch-apply')
+    this.dom_ss_pitch_read = document.querySelector('#ss-pitch-read')
+    this.dom_ss_distance_apply = document.querySelector('#ss-distance-apply')
+    this.dom_ss_distance_read = document.querySelector('#ss-distance-read')
+    this.dom_ss_silhouette = document.querySelector('#ss-silhouette')
+    this.dom_ss_background_color = document.querySelector('#ss-background-color')
+    this.dom_ss_one_row_per_direction = document.querySelector('#ss-one-row-per-direction')
+    this.dom_ss_preview_canvas = document.querySelector('#ss-preview-canvas')
+    this.dom_ss_direction_grid = document.querySelector('#ss-direction-grid')
+    this.dom_ss_select_all = document.querySelector('#ss-select-all')
+    this.dom_ss_select_cardinal = document.querySelector('#ss-select-cardinal')
+    this.dom_ss_select_diagonal = document.querySelector('#ss-select-diagonal')
+    this.dom_ss_reset_defaults = document.querySelector('#ss-reset-defaults')
+    this.dom_ss_apply_and_export = document.querySelector('#ss-apply-and-export')
+
 
     // UI for exporting the animation
     this.dom_export_button_hidden_link = document.querySelector('#download-hidden-link')

--- a/src/lib/processes/animations-listing/AnimationSearch.ts
+++ b/src/lib/processes/animations-listing/AnimationSearch.ts
@@ -16,15 +16,6 @@ export class AnimationSearch extends EventTarget {
   private custom_event: CustomEvent | null = null
   private show_selected_only: boolean = false
 
-  /** When false (default), animations that don't have a preview video are
-   *  hidden from the list. When true, all animations are shown regardless
-   *  of preview availability. Toggled by the "All" checkbox in the panel. */
-  private show_all: boolean = false
-
-  /** Set of animation names that have a preview video available, loaded
-   *  from animpreviews/manifest.json. null = manifest not yet loaded. */
-  private preview_manifest: Record<string, string[]> | null = null
-
   constructor (filter_input_id: string, animation_list_container_id: string, theme_manager: ThemeManager, skeleton_type: SkeletonType) {
     super()
     this.filter_input = document.querySelector(`#${filter_input_id}`)
@@ -32,30 +23,6 @@ export class AnimationSearch extends EventTarget {
     this.theme_manager = theme_manager
     this.skeleton_type = skeleton_type
     this.setup_event_listeners()
-    this.load_preview_manifest()
-  }
-
-  /** Asynchronously load the preview manifest so we know which animations
-   *  have a preview video. If it fails to load we treat all animations as
-   *  having previews (show everything) so the user isn't penalised. */
-  private async load_preview_manifest (): Promise<void> {
-    try {
-      const resp = await fetch('../animpreviews/manifest.json')
-      if (resp.ok) {
-        this.preview_manifest = await resp.json()
-      }
-    } catch {
-      // Network / file not found — fall back to null (show all).
-    }
-    // Re-render in case animations were already initialised before the
-    // manifest finished loading. Dispatch the event so the count label
-    // and any other listeners pick up the updated filtered list.
-    if (this.all_animations.length > 0) {
-      const filter_text = this.filter_input?.value.toLowerCase() ?? ''
-      this.render_filtered_animations(filter_text)
-      this.custom_event = new CustomEvent('filtered-animations-listing', { detail: { selectedAnimations: this.get_selected_animation_indices() } })
-      this.dispatchEvent(this.custom_event)
-    }
   }
 
   public initialize_animations (animations: TransformedAnimationClipPair[]): void {
@@ -168,30 +135,6 @@ export class AnimationSearch extends EventTarget {
     this.render_filtered_animations(filter_text)
   }
 
-  /** Toggle whether animations without a preview video are shown. */
-  public set_show_all (show_all: boolean): void {
-    this.show_all = show_all
-    const filter_text = this.filter_input?.value.toLowerCase() ?? ''
-    this.render_filtered_animations(filter_text)
-    // Dispatch event so the count label updates.
-    this.custom_event = new CustomEvent('filtered-animations-listing', { detail: { selectedAnimations: this.get_selected_animation_indices() } })
-    this.dispatchEvent(this.custom_event)
-  }
-
-  /** Check whether an animation has a preview video available, based on
-   *  the loaded manifest. Returns true if the manifest isn't loaded yet
-   *  (fail-open: don't hide things just because the manifest is slow).
-   *  The manifest stores filenames with spaces replaced by underscores,
-   *  so we normalise the animation name the same way before checking. */
-  private has_preview_video (anim_name: string): boolean {
-    if (this.preview_manifest === null) return true
-    const folder = RigConfig.by_skeleton_type(this.skeleton_type)?.animation_preview_folder ?? ''
-    const names = this.preview_manifest[folder]
-    if (names === undefined) return true
-    const file_safe_name = anim_name.replace(/ /g, '_')
-    return names.indexOf(file_safe_name) !== -1
-  }
-
   private render_filtered_animations (filter_text: string): void {
     if (this.animation_list_container === null) {
       return
@@ -203,12 +146,10 @@ export class AnimationSearch extends EventTarget {
       if (this.show_selected_only) {
         return matches_search && animation.isChecked === true
       }
-      // When show_all is false (default), hide library animations that
-      // don't have a preview video. Custom-imported animations are always
-      // shown (they're user-added, not from the library).
+      // Custom-imported animations are always shown
       const is_custom = animation.metadata?.source_type === 'custom-import'
-      if (!this.show_all && !is_custom && !this.has_preview_video(animation.name)) {
-        return false
+      if (is_custom) {
+        return matches_search
       }
       return matches_search
     })

--- a/src/lib/processes/animations-listing/AnimationSearch.ts
+++ b/src/lib/processes/animations-listing/AnimationSearch.ts
@@ -16,6 +16,15 @@ export class AnimationSearch extends EventTarget {
   private custom_event: CustomEvent | null = null
   private show_selected_only: boolean = false
 
+  /** When false (default), animations that don't have a preview video are
+   *  hidden from the list. When true, all animations are shown regardless
+   *  of preview availability. Toggled by the "All" checkbox in the panel. */
+  private show_all: boolean = false
+
+  /** Set of animation names that have a preview video available, loaded
+   *  from animpreviews/manifest.json. null = manifest not yet loaded. */
+  private preview_manifest: Record<string, string[]> | null = null
+
   constructor (filter_input_id: string, animation_list_container_id: string, theme_manager: ThemeManager, skeleton_type: SkeletonType) {
     super()
     this.filter_input = document.querySelector(`#${filter_input_id}`)
@@ -23,6 +32,30 @@ export class AnimationSearch extends EventTarget {
     this.theme_manager = theme_manager
     this.skeleton_type = skeleton_type
     this.setup_event_listeners()
+    this.load_preview_manifest()
+  }
+
+  /** Asynchronously load the preview manifest so we know which animations
+   *  have a preview video. If it fails to load we treat all animations as
+   *  having previews (show everything) so the user isn't penalised. */
+  private async load_preview_manifest (): Promise<void> {
+    try {
+      const resp = await fetch('../animpreviews/manifest.json')
+      if (resp.ok) {
+        this.preview_manifest = await resp.json()
+      }
+    } catch {
+      // Network / file not found — fall back to null (show all).
+    }
+    // Re-render in case animations were already initialised before the
+    // manifest finished loading. Dispatch the event so the count label
+    // and any other listeners pick up the updated filtered list.
+    if (this.all_animations.length > 0) {
+      const filter_text = this.filter_input?.value.toLowerCase() ?? ''
+      this.render_filtered_animations(filter_text)
+      this.custom_event = new CustomEvent('filtered-animations-listing', { detail: { selectedAnimations: this.get_selected_animation_indices() } })
+      this.dispatchEvent(this.custom_event)
+    }
   }
 
   public initialize_animations (animations: TransformedAnimationClipPair[]): void {
@@ -135,6 +168,30 @@ export class AnimationSearch extends EventTarget {
     this.render_filtered_animations(filter_text)
   }
 
+  /** Toggle whether animations without a preview video are shown. */
+  public set_show_all (show_all: boolean): void {
+    this.show_all = show_all
+    const filter_text = this.filter_input?.value.toLowerCase() ?? ''
+    this.render_filtered_animations(filter_text)
+    // Dispatch event so the count label updates.
+    this.custom_event = new CustomEvent('filtered-animations-listing', { detail: { selectedAnimations: this.get_selected_animation_indices() } })
+    this.dispatchEvent(this.custom_event)
+  }
+
+  /** Check whether an animation has a preview video available, based on
+   *  the loaded manifest. Returns true if the manifest isn't loaded yet
+   *  (fail-open: don't hide things just because the manifest is slow).
+   *  The manifest stores filenames with spaces replaced by underscores,
+   *  so we normalise the animation name the same way before checking. */
+  private has_preview_video (anim_name: string): boolean {
+    if (this.preview_manifest === null) return true
+    const folder = RigConfig.by_skeleton_type(this.skeleton_type)?.animation_preview_folder ?? ''
+    const names = this.preview_manifest[folder]
+    if (names === undefined) return true
+    const file_safe_name = anim_name.replace(/ /g, '_')
+    return names.indexOf(file_safe_name) !== -1
+  }
+
   private render_filtered_animations (filter_text: string): void {
     if (this.animation_list_container === null) {
       return
@@ -145,6 +202,13 @@ export class AnimationSearch extends EventTarget {
       const matches_search = animation.name.toLowerCase().includes(filter_text)
       if (this.show_selected_only) {
         return matches_search && animation.isChecked === true
+      }
+      // When show_all is false (default), hide library animations that
+      // don't have a preview video. Custom-imported animations are always
+      // shown (they're user-added, not from the library).
+      const is_custom = animation.metadata?.source_type === 'custom-import'
+      if (!this.show_all && !is_custom && !this.has_preview_video(animation.name)) {
+        return false
       }
       return matches_search
     })
@@ -181,9 +245,15 @@ export class AnimationSearch extends EventTarget {
       const theme_name: string = this.theme_manager.get_current_theme()
       const is_custom_animation = animation_clip.metadata?.source_type === 'custom-import'
 
+      // The preview video filename uses underscores where the animation
+      // clip name uses spaces (e.g. clip "Consume Item" -> file
+      // "dark_Consume_Item.mp4"). We normalise by replacing spaces with
+      // underscores so the URL has no spaces (which browsers/servers
+      // mishandle, returning text/html instead of video/mp4).
+      const file_safe_anim_name = anim_name.replace(/ /g, '_')
       const preview_data_src_attribute = is_custom_animation
         ? ''
-        : ` data-src="../animpreviews/${preview_folder}/${theme_name}_${anim_name}.mp4"`
+        : ` data-src="../animpreviews/${preview_folder}/${theme_name}_${file_safe_anim_name}.mp4"`
 
       const custom_animation_badge_html = is_custom_animation
         ? '<span class="anim-custom-badge" title="Custom animation" aria-label="Custom animation">C</span>'
@@ -282,43 +352,5 @@ export class AnimationSearch extends EventTarget {
       this.filter_input.value = ''
       this.render_filtered_animations('')
     }
-  }
-
-  public toggle_select_all_animations (): void {
-    // Check if all animations are currently selected
-    const all_selected = this.all_animations.every(animation => animation.isChecked === true)
-
-    // Toggle the state: if all are selected, deselect all; otherwise, select all
-    const new_state = !all_selected
-    this.all_animations.forEach(animation => {
-      animation.isChecked = new_state
-    })
-
-    // Update all checkboxes in the UI
-    this.update_all_checkboxes_in_ui(new_state)
-
-    // Save the checkbox states to ensure they're synced with the UI
-    this.save_current_checkbox_states()
-
-    // If in "selected only" mode, re-render to update the displayed animations
-    if (this.show_selected_only) {
-      const filter_text = this.filter_input?.value.toLowerCase() ?? ''
-      this.render_filtered_animations(filter_text)
-    }
-
-    // Emit event to notify that export options have changed
-    this.custom_event = new CustomEvent('export-options-changed', { detail: { selectedAnimations: this.get_selected_animation_indices() } })
-    this.dispatchEvent(this.custom_event)
-  }
-
-  private update_all_checkboxes_in_ui (checked_state: boolean): void {
-    if (this.animation_list_container === null) {
-      return
-    }
-
-    const checkboxes = this.animation_list_container.querySelectorAll('input[type="checkbox"]')
-    checkboxes.forEach((checkbox) => {
-      (checkbox as HTMLInputElement).checked = checked_state
-    })
   }
 }

--- a/src/lib/processes/animations-listing/StepAnimationsListing.ts
+++ b/src/lib/processes/animations-listing/StepAnimationsListing.ts
@@ -495,12 +495,6 @@ export class StepAnimationsListing extends EventTarget {
       })
     })
 
-    // -------- "All" checkbox: toggle showing animations without previews --------
-    const show_all_cb = document.getElementById('animation-show-all') as HTMLInputElement | null
-    show_all_cb?.addEventListener('change', () => {
-      this.animation_search?.set_show_all(show_all_cb.checked)
-    })
-
     // helps ensure we don't add event listeners multiple times
     this.has_added_event_listeners = true
   }

--- a/src/lib/processes/animations-listing/StepAnimationsListing.ts
+++ b/src/lib/processes/animations-listing/StepAnimationsListing.ts
@@ -94,8 +94,11 @@ export class StepAnimationsListing extends EventTarget {
       this.ui.dom_skinned_mesh_tools.style.display = 'flex'
     }
 
+    // The sidebar holds the Animations / Sprite Sheet tabs now; a plain
+    // block (not flex) is fine because each tab panel handles its own
+    // layout via .sidebar-tab-panel.active { display: flex ... }.
     if (this.ui.dom_skinned_mesh_animation_tools != null) {
-      this.ui.dom_skinned_mesh_animation_tools.style.display = 'flex'
+      this.ui.dom_skinned_mesh_animation_tools.style.display = 'block'
     }
 
     // bone display toggle only works in animation preview since
@@ -148,6 +151,11 @@ export class StepAnimationsListing extends EventTarget {
     if (this.ui.dom_export_button !== null) {
       this.ui.dom_export_button.disabled = true
     }
+  }
+
+  
+  public current_animation_index (): number {
+    return this.current_playing_index
   }
 
   public mixer (): AnimationMixer {
@@ -487,11 +495,10 @@ export class StepAnimationsListing extends EventTarget {
       })
     })
 
-    // event listener for select all / deselect all button
-    const toggle_select_all_button = document.querySelector('#toggle-select-all-animations')
-    toggle_select_all_button?.addEventListener('click', () => {
-      this.animation_search?.toggle_select_all_animations()
-      this.update_download_button_enabled()
+    // -------- "All" checkbox: toggle showing animations without previews --------
+    const show_all_cb = document.getElementById('animation-show-all') as HTMLInputElement | null
+    show_all_cb?.addEventListener('change', () => {
+      this.animation_search?.set_show_all(show_all_cb.checked)
     })
 
     // helps ensure we don't add event listeners multiple times

--- a/src/lib/sprite-sheet/SpriteSheetExporter.ts
+++ b/src/lib/sprite-sheet/SpriteSheetExporter.ts
@@ -1,0 +1,450 @@
+import * as THREE from 'three'
+import {
+  type AnimationClip,
+  type AnimationMixer,
+  type SkinnedMesh,
+  type Scene,
+  OrthographicCamera,
+  WebGLRenderer,
+  PerspectiveCamera,
+  type AnimationAction,
+  type Object3D,
+  MeshBasicMaterial,
+  Color
+} from 'three'
+import { SpriteSheetSettings, type DirectionEntry } from './SpriteSheetSettings.ts'
+
+export interface SpriteSheetExportResult {
+  blob: Blob
+  total_width: number
+  total_height: number
+  frame_count: number
+  direction_count: number
+  /** How many frames actually fit on the sheet. When this is less than
+   *  frame_count * direction_count, the user requested more cells than
+   *  the canvas can hold; we silently drop the tail. */
+  cells_rendered: number
+  /** Cells skipped because they would overflow the canvas. */
+  cells_overflow: number
+  /** Actual frame width / height used after clamping to fit the canvas.
+   *  May be smaller than the user-requested frame_w/h if the canvas is
+   *  too small to fit all cells at full size. */
+  rendered_frame_width: number
+  rendered_frame_height: number
+}
+
+export class SpriteSheetExporter {
+  /**
+   * Export a sprite sheet from the given animation.
+   *
+   * Canvas-first layout: the canvas dimensions drive the sheet size. The
+   * frame width/height is clamped down to whatever fits in the canvas at
+   * the requested cell count, while preserving the requested aspect ratio.
+   * If the user asked for more cells than fit at any non-zero frame size,
+   * we warn and drop the tail.
+   */
+  public static async export (
+    skinned_meshes: SkinnedMesh[],
+    clip: AnimationClip,
+    mixer: AnimationMixer,
+    settings: SpriteSheetSettings,
+    main_scene: Scene,
+    on_progress?: (pct: number) => void
+  ): Promise<SpriteSheetExportResult> {
+    const fps = 30
+    const total_frames = Math.floor(clip.duration * fps)
+    const sample_interval = Math.max(1, Math.round(settings.sample_every_n_frames))
+
+    // Build array of frame indices to sample
+    const frame_indices: number[] = []
+    for (let i = 0; i < total_frames; i += sample_interval) {
+      frame_indices.push(i)
+    }
+    if (frame_indices[frame_indices.length - 1] < total_frames - 1) {
+      frame_indices.push(total_frames - 1)
+    }
+
+    const directions = settings.enabled_directions()
+    const requested_fw = Math.max(16, Math.round(settings.frame_width))
+    const requested_fh = Math.max(16, Math.round(settings.frame_height))
+    const pad = Math.max(0, Math.round(settings.padding))
+    const canvas_w = Math.max(64, Math.round(settings.canvas_width))
+    const canvas_h = Math.max(64, Math.round(settings.canvas_height))
+
+    // ---- Grid layout ----
+    // When one_row_per_direction is true (legacy): rows = directions, cols = frames.
+    // When false (default): all cells flow left-to-right, top-to-bottom with
+    // auto-wrap. cols = canvas capacity, rows = ceil(total / cols).
+    const total_cells = frame_indices.length * directions.length
+    let requested_cols: number
+    let requested_rows: number
+    if (settings.one_row_per_direction) {
+      requested_cols = frame_indices.length
+      requested_rows = directions.length
+    } else {
+      // Flow layout: pack as many cells per row as the canvas allows.
+      const max_cols_by_canvas = Math.max(1, Math.floor((canvas_w + pad) / (requested_fw + pad)))
+      const max_rows_by_canvas = Math.max(1, Math.floor((canvas_h + pad) / (requested_fh + pad)))
+      requested_cols = Math.min(max_cols_by_canvas, total_cells)
+      requested_rows = Math.ceil(total_cells / requested_cols)
+      // Silently cap rows to canvas capacity; overflow warning below handles the rest.
+      if (requested_rows > max_rows_by_canvas) {
+        requested_rows = max_rows_by_canvas
+      }
+    }
+
+    if (frame_indices.length === 0 || directions.length === 0) {
+      throw new Error('SpriteSheet: no frames or directions selected')
+    }
+        /*  1. Frame size is inviolable — canvas just frames the result   */
+        /* ---------------------------------------------------------------- */
+        // The user-set frame_width / frame_height is the one thing that
+        // must NOT change: it's the pixel size at which each model frame is
+        // rendered. Both the WebGL renderer viewport and the destination
+        // drawImage call use these exact dimensions. The canvas_w/h is
+        // simply the bounding "container" that determines when the entire
+        // sheet overflows — extra canvas room stays blank.
+        const cell_w = requested_fw
+        const cell_h = requested_fh
+
+        // How much vertical / horizontal space the cell grid actually
+        // occupies in the canvas.
+        const sheet_w = requested_cols * (cell_w + pad) - pad
+        const sheet_h = requested_rows * (cell_h + pad) - pad
+
+        // If the grid doesn't fit in the canvas, the user wants to know.
+        // We still render what fits in the chosen dimensions — the cell
+        // size is non-negotiable per the spec; what we drop is the cells
+        // that wouldn't have fit at all.
+        let cols_render = requested_cols
+        let rows_render = requested_rows
+        let cells_overflow = 0
+        if (sheet_w > canvas_w || sheet_h > canvas_h) {
+          // Limit rendering to what fits in the chosen canvas.
+          cols_render = Math.max(1, Math.floor((canvas_w + pad) / (cell_w + pad)))
+          rows_render = Math.max(1, Math.floor((canvas_h + pad) / (cell_h + pad)))
+        }
+        // Clamp rows_render to whatever directions are actually available.
+        // This clamp is ONLY valid for the legacy "1 row per direction"
+        // layout, where each row maps to exactly one direction, so rows can
+        // never exceed the enabled direction count. In flow layout (false),
+        // rows_render is a purely geometric value — how many rows of cells
+        // fit in the canvas — and must NOT be limited by the direction
+        // count, otherwise a single direction with many frames can't wrap
+        // to the next row and gets silently truncated.
+        if (settings.one_row_per_direction && rows_render > directions.length) {
+          rows_render = directions.length
+        }
+        cells_overflow = (requested_cols * requested_rows) - (cols_render * rows_render)
+        if (cells_overflow > 0) {
+          console.warn(
+            `SpriteSheet: ${cells_overflow} of ${requested_cols * requested_rows} cells don't fit on the ` +
+            `${canvas_w}×${canvas_h} canvas (each cell is ${cell_w}×${cell_h}). ` +
+            `Increase the canvas size, decrease frame size, or sample fewer frames/directions.`
+          )
+        }
+
+        /* ---------------------------------------------------------------- */
+            /*  2. Temporarily modify main scene for capture                    */
+            /* ---------------------------------------------------------------- */
+            const saved_bg = main_scene.background
+                const saved_fog = main_scene.fog
+                if (settings.silhouette) {
+                  if (settings.silhouette) {
+                    main_scene.background = new THREE.Color(0x00ff00)
+                  } else {
+                    // Color mode: user-chosen background color. Default green so
+                    // the output is chroma-key friendly. We avoid fully transparent
+                    // backgrounds because the WebGLRenderer + 2D canvas drawImage
+                    // path can drop colors to near-black when the scene's background
+                    // is null (the framebuffer comes back essentially empty and the
+                    // 2D context composites as opaque black).
+                    main_scene.background = new THREE.Color(settings.background_color)
+                  }
+                }
+
+    // Hide helpers / decorative objects
+    const hidden_objects: Object3D[] = []
+    main_scene.traverse((obj) => {
+      if (
+        (obj.name === 'Setup objects' || obj.name === 'Skeleton Helper' ||
+         obj.name.includes('Helper') || obj.name.includes('helper') ||
+         obj.type === 'GridHelper' || obj.type === 'ArrowHelper' ||
+         obj.type === 'TransformControls' || obj.type === 'TransformControlsPlane') &&
+        obj.visible
+      ) {
+        hidden_objects.push(obj)
+        obj.visible = false
+      }
+    })
+
+    // For silhouette mode, swap every skinned mesh's material to a flat
+    // black material so the output is a clean black shape on green.
+    // We restore the originals when done.
+    const material_swaps: Array<{ mesh: SkinnedMesh; original: THREE.Material | THREE.Material[] }> = []
+    if (settings.silhouette) {
+      const black = new MeshBasicMaterial({ color: 0x000000 })
+      for (const mesh of skinned_meshes) {
+        material_swaps.push({ mesh, original: mesh.material })
+        mesh.material = black
+      }
+    }
+
+    /* ---------------------------------------------------------------- */
+    /*  3. Hidden renderer                                              */
+    /* ---------------------------------------------------------------- */
+    const renderer = new WebGLRenderer({
+      alpha: true,
+      antialias: true,
+      preserveDrawingBuffer: true
+    })
+    renderer.setSize(cell_w, cell_h)
+    renderer.setPixelRatio(1)
+    if (settings.silhouette) {
+      renderer.setClearColor(0x00ff00, 1)
+    } else {
+      // Color mode: the user-chosen background color. Default is green
+      // (#00ff00) so the output is chroma-key friendly. We avoid fully
+      // transparent backgrounds because the WebGLRenderer + 2D canvas
+      // drawImage path can drop colors to near-black when the framebuffer
+      // comes back as (0,0,0,0).
+      renderer.setClearColor(settings.background_color, 1)
+    }
+    // Match the live preview renderer's settings (SpriteSheetUI's preview
+    // canvas) — which works correctly for color rendering. The main
+    // scene renderer uses ACESFilmicToneMapping + SRGB output, but
+    // applying those on the new export renderer in combination with the
+    // orthographic camera was producing a near-black silhouette in
+    // color mode (the user-reported bug). Skipping them here restores
+    // the original color values straight from the GLB materials.
+    renderer.outputColorSpace = THREE.LinearSRGBColorSpace
+    renderer.toneMapping = THREE.NoToneMapping
+    // CRITICAL: the main scene's lights (DirectionalLight intensity=1.0,
+    // AmbientLight intensity=1.2) are authored in "legacy" light units
+    // (the convention when Mesh2Motion was first written). three.js r155+
+    // made physical lights the only mode, but main_scene was built
+    // against the old convention. A fresh WebGLRenderer interprets those
+    // intensities in physical units and produces a near-black render
+    // even though the model's base color is white. We can either force
+    // legacy mode (useLegacyLights, removed in r165+) OR temporarily
+    // boost intensities. The cleanest fix is the latter — restore the
+    // original intensities after we render each cell.
+    const saved_light_intensities: Array<{ light: any; original: number }> = []
+    const hidden_lights: any[] = []
+    if (!settings.silhouette) {
+      main_scene.traverse((obj: any) => {
+        if (obj.isLight && obj.intensity !== undefined) {
+          // Try multiple strategies to make sure the model is lit:
+          // 1. Boost intensity 30x
+          // 2. Also add a flat ambient light for guaranteed minimum
+          saved_light_intensities.push({ light: obj, original: obj.intensity })
+          obj.intensity = obj.intensity * 30
+        }
+      })
+      // Add a bright AmbientLight as a guaranteed floor — this should
+      // make any PBR material at least show its base color, even if
+      // DirectionalLight / shadow setup is wrong.
+      const ambient = new THREE.AmbientLight(0xffffff, 5.0)
+      main_scene.add(ambient)
+      hidden_lights.push(ambient)
+    }
+    renderer.domElement.style.position = 'fixed'
+    renderer.domElement.style.top = '-9999px'
+    renderer.domElement.style.left = '-9999px'
+    document.body.appendChild(renderer.domElement)
+
+    /* ---------------------------------------------------------------- */
+    /*  4. Orthographic camera sized to model                           */
+    /* ---------------------------------------------------------------- */
+    /* ---------------------------------------------------------------- */
+        /*  4. Camera — perspective, mirrors the preview                    */
+        /* ---------------------------------------------------------------- */
+        // Use the same PerspectiveCamera type and fov as the sprite-sheet
+        // preview (45° vertical fov, see SpriteSheetUI.start_live_preview).
+        // The renderer viewport is set to the cell size below, so what we
+        // render here is the model as it would appear in a (cell_w × cell_h)
+        // preview at the user-configured pitch + distance. This means
+        // tweaking distance or pitch in the panel moves the model in the
+        // exported sprite the same way it moves in the live preview.
+        //
+        // Cell aspect is set on the camera directly — non-square cells get a
+        // non-square frustum so the model fits without stretching the way it
+        // would in an orthographic projection.
+        const box = new THREE.Box3()
+        for (const mesh of skinned_meshes) {
+          mesh.updateWorldMatrix(true, true)
+          box.expandByObject(mesh)
+        }
+        const center = box.getCenter(new THREE.Vector3())
+
+        const pitch_rad = (settings.pitch_angle_degrees * Math.PI) / 180
+        const export_distance = Math.max(0.1, settings.camera_distance)
+        const export_horizontal = export_distance * Math.cos(pitch_rad)
+        const export_vertical = export_distance * Math.sin(pitch_rad)
+
+        const camera = new PerspectiveCamera(
+          45,
+          cell_w / cell_h,
+          0.1,
+          100
+        )
+
+    /* ---------------------------------------------------------------- */
+    /*  5. Prepare animation actions for seeking                        */
+    /* ---------------------------------------------------------------- */
+    // Stop any existing actions so we start fresh
+    mixer.stopAllAction()
+
+    const actions: AnimationAction[] = []
+    for (const mesh of skinned_meshes) {
+      const action = mixer.clipAction(clip, mesh)
+      if (action) {
+        action.play()
+        actions.push(action)
+      }
+    }
+
+    /* ---------------------------------------------------------------- */
+    /*  6. Render each cell and composite onto the output canvas        */
+    /* ---------------------------------------------------------------- */
+    const canvas = document.createElement('canvas')
+    canvas.width = canvas_w
+    canvas.height = canvas_h
+    const ctx = canvas.getContext('2d')!
+    // Fill with green / transparent so missing pixels stay chroma-key-friendly
+    if (settings.silhouette) {
+      ctx.fillStyle = '#00ff00'
+    } else {
+      // Color mode: user-chosen background. fillStyle is a CSS hex
+      // string; settings stores the raw integer 0xRRGGBB.
+      ctx.fillStyle = '#' + settings.background_color.toString(16).padStart(6, '0')
+    }
+    ctx.fillRect(0, 0, canvas_w, canvas_h)
+
+    const total_render_cells = rows_render * cols_render
+    let cells_done = 0
+
+    // pitch_rad / export_distance / export_horizontal / export_vertical
+    // are computed once above when the PerspectiveCamera is created; they're
+    // reused in the per-direction orbit loop below.
+
+    if (settings.one_row_per_direction) {
+      // Legacy layout: one direction per row, frames across columns.
+      for (let row = 0; row < rows_render; row++) {
+        const dir = directions[row]
+        if (!dir) {
+          console.warn(`SpriteSheet: skipping row ${row}; only ${directions.length} direction(s) available.`)
+          continue
+        }
+        const angle = dir.angle
+        const cam_x = center.x + export_horizontal * Math.sin(angle)
+        const cam_z = center.z + export_horizontal * Math.cos(angle)
+        const cam_y = center.y + export_vertical
+        camera.position.set(cam_x, cam_y, cam_z)
+        camera.lookAt(center)
+
+        for (let col = 0; col < cols_render; col++) {
+          const frame_idx = frame_indices[col]
+          const time = frame_idx / fps
+          for (const action of actions) { action.time = time }
+          mixer.update(0)
+          for (const mesh of skinned_meshes) { mesh.updateMatrixWorld(true) }
+
+          renderer.render(main_scene, camera)
+          const dst_x = col * (cell_w + pad)
+          const dst_y = row * (cell_h + pad)
+          ctx.drawImage(renderer.domElement, 0, 0, cell_w, cell_h, dst_x, dst_y, cell_w, cell_h)
+
+          cells_done++
+          on_progress?.(cells_done / total_render_cells)
+          if (cells_done % 16 === 0) { await new Promise((r) => setTimeout(r, 0)) }
+        }
+      }
+    } else {
+      // Flow layout: all cells flow left-to-right, top-to-bottom with auto-wrap.
+      // Cell order: dir0_f0, dir0_f1, ..., dir0_fN, dir1_f0, dir1_f1, ...
+      for (let flat = 0; flat < total_render_cells; flat++) {
+        const dir_idx = Math.floor(flat / frame_indices.length)
+        const frame_idx_in_dir = flat % frame_indices.length
+        const dir = directions[dir_idx]
+        if (!dir) {
+          console.warn(`SpriteSheet: skipping flat ${flat}; dir ${dir_idx} not available.`)
+          continue
+        }
+        const angle = dir.angle
+        const cam_x = center.x + export_horizontal * Math.sin(angle)
+        const cam_z = center.z + export_horizontal * Math.cos(angle)
+        const cam_y = center.y + export_vertical
+        camera.position.set(cam_x, cam_y, cam_z)
+        camera.lookAt(center)
+
+        const frame_idx = frame_indices[frame_idx_in_dir]
+        const time = frame_idx / fps
+        for (const action of actions) { action.time = time }
+        mixer.update(0)
+        for (const mesh of skinned_meshes) { mesh.updateMatrixWorld(true) }
+
+        renderer.render(main_scene, camera)
+        const col = flat % cols_render
+        const row = Math.floor(flat / cols_render)
+        const dst_x = col * (cell_w + pad)
+        const dst_y = row * (cell_h + pad)
+        ctx.drawImage(renderer.domElement, 0, 0, cell_w, cell_h, dst_x, dst_y, cell_w, cell_h)
+
+        cells_done++
+        on_progress?.(cells_done / total_render_cells)
+        if (cells_done % 16 === 0) { await new Promise((r) => setTimeout(r, 0)) }
+      }
+    }
+
+    /* ---------------------------------------------------------------- */
+    /*  7. Cleanup                                                      */
+    /* ---------------------------------------------------------------- */
+    for (const action of actions) {
+      action.stop()
+    }
+
+    // Restore materials swapped for silhouette mode.
+    for (const swap of material_swaps) {
+      swap.mesh.material = swap.original
+    }
+
+    // Restore any light intensities we boosted for physical-light
+    // compatibility (see the corresponding boost in step 3).
+    for (const saved of saved_light_intensities) {
+      saved.light.intensity = saved.original
+    }
+    // Remove any temporary lights we added.
+    for (const light of hidden_lights) {
+      main_scene.remove(light)
+    }
+
+    renderer.dispose()
+    document.body.removeChild(renderer.domElement)
+
+    main_scene.background = saved_bg
+    main_scene.fog = saved_fog
+    for (const obj of hidden_objects) {
+      obj.visible = true
+    }
+
+    /* ---------------------------------------------------------------- */
+    /*  8. Produce PNG blob                                             */
+    /* ---------------------------------------------------------------- */
+    const blob: Blob = await new Promise((resolve) => {
+      canvas.toBlob((b) => resolve(b!), 'image/png')
+    })
+
+    return {
+      blob,
+      total_width: canvas_w,
+      total_height: canvas_h,
+      frame_count: cols_render,
+      direction_count: settings.one_row_per_direction ? rows_render : 1,
+      cells_rendered: cells_done,
+      cells_overflow,
+      rendered_frame_width: cell_w,
+      rendered_frame_height: cell_h
+    }
+  }
+}

--- a/src/lib/sprite-sheet/SpriteSheetSettings.ts
+++ b/src/lib/sprite-sheet/SpriteSheetSettings.ts
@@ -1,0 +1,206 @@
+/**
+ * SpriteSheetSettings — sprite sheet export configuration with localStorage persistence.
+ *
+ * Persistent keys are prefixed 'mesh2motion-sprite-sheet:' so they don't collide with other
+ * app settings.
+ */
+
+export interface DirectionEntry {
+  readonly id: string
+  readonly label: string
+  readonly short_label: string
+  readonly angle: number
+  enabled: boolean
+}
+
+const ALL_DIRECTIONS: DirectionEntry[] = [
+  { id: 'S',  label: '\u4e0b (Front)',     short_label: '\u4e0b', angle: 0,           enabled: true },
+  { id: 'SW', label: '\u53f3\u4e0b (Fwd-R)', short_label: '\u53f3\u4e0b', angle: Math.PI / 4, enabled: true },
+  { id: 'W',  label: '\u53f3 (Right)',       short_label: '\u53f3', angle: Math.PI / 2, enabled: true },
+  { id: 'NW', label: '\u53f3\u4e0a (Bck-R)', short_label: '\u53f3\u4e0a', angle: 3 * Math.PI / 4, enabled: true },
+  { id: 'N',  label: '\u4e0a (Back)',       short_label: '\u4e0a', angle: Math.PI,     enabled: true },
+  { id: 'NE', label: '\u5de6\u4e0a (Bck-L)', short_label: '\u5de6\u4e0a', angle: 5 * Math.PI / 4, enabled: true },
+  { id: 'E',  label: '\u5de6 (Left)',       short_label: '\u5de6', angle: 3 * Math.PI / 2, enabled: true },
+  { id: 'SE', label: '\u5de6\u4e0b (Fwd-L)', short_label: '\u5de6\u4e0b', angle: 7 * Math.PI / 4, enabled: true },
+]
+
+export const DIRECTION_COUNT = ALL_DIRECTIONS.length
+
+export interface SpriteSheetSettingsJSON {
+  sample_every_n_frames: number
+  canvas_width: number
+  canvas_height: number
+  frame_width: number
+  frame_height: number
+  padding: number
+  pitch_angle_degrees: number
+  camera_distance: number
+  silhouette: boolean
+  background_color: number
+  one_row_per_direction: boolean
+  directions: Array<{ id: string; enabled: boolean }>
+}
+
+const STORAGE_KEY = 'mesh2motion-sprite-sheet:settings'
+
+/** Pitch range in degrees. 0 = camera at model's mid-height (horizontal view).
+ *  Positive = camera above model (looking down at head/top), negative = below. */
+const PITCH_MIN_DEG = -80
+const PITCH_MAX_DEG = 80
+const PITCH_DEFAULT_DEG = 60
+
+/** Camera distance range (world units, matches OrbitControls min/max distance). */
+const DISTANCE_MIN = 1
+const DISTANCE_MAX = 50
+const DISTANCE_DEFAULT = 10
+
+/** Canvas size range. We default to 1024×1024 so the sheet is roughly square
+ *  — much more useful than a single long horizontal strip. Users can still
+ *  override per-export via the panel. */
+const CANVAS_MIN = 64
+const CANVAS_MAX = 4096
+const CANVAS_DEFAULT = 1024
+
+export class SpriteSheetSettings {
+  public sample_every_n_frames: number = 1
+  public canvas_width: number = CANVAS_DEFAULT
+  public canvas_height: number = CANVAS_DEFAULT
+  public frame_width: number = 128
+  public frame_height: number = 128
+  // Default the padding to 0 so a default 1024×1024 canvas with 128×128 frames
+  // can fit the full 8 × 24 grid of one of the bundled animations with no
+  // overflow warning. Users can still raise it for visual separation.
+  public padding: number = 0
+  public pitch_angle_degrees: number = PITCH_DEFAULT_DEG
+  public camera_distance: number = DISTANCE_DEFAULT
+  // Default the silhouette to OFF — most users want color. Toggle ON to
+  // get the legacy black-on-green look that game engines can chroma-key.
+  public silhouette: boolean = false
+  // When false (default), cells are laid out col-major: the first action's
+  // frames fill row 0 left-to-right, then the next direction, then continue
+  // wrapping rows. When true, the grid is laid out with one direction per
+  // row (the legacy "1 row per direction" style). With a single animation
+  // the two modes differ only when rows > directions_enabled; multi-action
+  // support is planned.
+  public one_row_per_direction: boolean = false
+  // Background color used in both silhouette and color modes. Default is
+  // green (#00ff00) because it's the most common chroma-key color for
+  // sprite sheet workflows — game engines can punch out the green pixels
+  // to get a transparent character sprite. Users can override to white,
+  // black, or any other color via the panel.
+  public background_color: number = 0x00ff00
+  public readonly directions: DirectionEntry[]
+
+  constructor () {
+    this.directions = ALL_DIRECTIONS.map(d => ({ ...d }))
+  }
+
+  public enabled_directions (): DirectionEntry[] {
+    return this.directions.filter(d => d.enabled)
+  }
+
+  public enabled_direction_count (): number {
+    return this.directions.filter(d => d.enabled).length
+  }
+
+  public all_selected (): boolean {
+    return this.directions.every(d => d.enabled)
+  }
+
+  public set_cardinal_only (): void {
+    const cardinal = new Set(['S', 'N', 'E', 'W'])
+    this.directions.forEach(d => { d.enabled = cardinal.has(d.id) })
+  }
+
+  public set_diagonal_only (): void {
+    const diagonal = new Set(['SW', 'NW', 'NE', 'SE'])
+    this.directions.forEach(d => { d.enabled = diagonal.has(d.id) })
+  }
+
+  public set_all (enabled: boolean): void {
+    this.directions.forEach(d => { d.enabled = enabled })
+  }
+
+  public save (): void {
+    const json: SpriteSheetSettingsJSON = {
+      sample_every_n_frames: this.sample_every_n_frames,
+      canvas_width: this.canvas_width,
+      canvas_height: this.canvas_height,
+      frame_width: this.frame_width,
+      frame_height: this.frame_height,
+      padding: this.padding,
+      pitch_angle_degrees: this.pitch_angle_degrees,
+      camera_distance: this.camera_distance,
+      silhouette: this.silhouette,
+      background_color: this.background_color,
+      one_row_per_direction: this.one_row_per_direction,
+      directions: this.directions.map(d => ({ id: d.id, enabled: d.enabled }))
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(json))
+    } catch {
+      console.warn('SpriteSheetSettings: failed to save to localStorage')
+    }
+  }
+
+  public load (): void {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (raw === null) return
+      const json: SpriteSheetSettingsJSON = JSON.parse(raw)
+
+      this.sample_every_n_frames = clamp(json.sample_every_n_frames ?? 1, 1, 60)
+      this.canvas_width = clamp(json.canvas_width ?? CANVAS_DEFAULT, CANVAS_MIN, CANVAS_MAX)
+      this.canvas_height = clamp(json.canvas_height ?? CANVAS_DEFAULT, CANVAS_MIN, CANVAS_MAX)
+      this.frame_width = clamp(json.frame_width ?? 128, 16, 2048)
+      this.frame_height = clamp(json.frame_height ?? 128, 16, 2048)
+      this.padding = clamp_int(json.padding ?? 0, 0, 128)
+      this.pitch_angle_degrees = clamp(json.pitch_angle_degrees ?? PITCH_DEFAULT_DEG, PITCH_MIN_DEG, PITCH_MAX_DEG)
+      this.camera_distance = clamp(json.camera_distance ?? DISTANCE_DEFAULT, DISTANCE_MIN, DISTANCE_MAX)
+      this.silhouette = json.silhouette ?? false
+      this.one_row_per_direction = json.one_row_per_direction ?? false
+      // background_color: a 24-bit RGB integer (0xRRGGBB). Reject values
+      // outside that range so a corrupted localStorage entry can't make
+      // the canvas invisible.
+      this.background_color = clamp_int(json.background_color ?? 0x00ff00, 0, 0xffffff)
+
+      if (Array.isArray(json.directions)) {
+        const dir_map = new Map(json.directions.map(d => [d.id, d.enabled]))
+        for (const dir of this.directions) {
+          if (dir_map.has(dir.id)) {
+            dir.enabled = dir_map.get(dir.id)!
+          }
+        }
+      }
+    } catch {
+      console.warn('SpriteSheetSettings: parse failed, using defaults')
+      this.reset_defaults()
+    }
+  }
+
+  public reset_defaults (): void {
+    this.sample_every_n_frames = 1
+    this.canvas_width = CANVAS_DEFAULT
+    this.canvas_height = CANVAS_DEFAULT
+    this.frame_width = 128
+    this.frame_height = 128
+    this.padding = 0
+    this.pitch_angle_degrees = PITCH_DEFAULT_DEG
+    this.camera_distance = DISTANCE_DEFAULT
+    this.silhouette = false
+    this.background_color = 0x00ff00
+    this.one_row_per_direction = false
+    this.directions.forEach(d => { d.enabled = true })
+  }
+}
+
+function clamp (v: number, lo: number, hi: number): number {
+  return Math.min(Math.max(v, lo), hi)
+}
+
+function clamp_int (v: number, lo: number, hi: number): number {
+  // Like clamp, but for integer RGB values. We round and ensure the
+  // result is a non-fractional integer inside [lo, hi].
+  if (!Number.isFinite(v)) return lo
+  return Math.min(Math.max(Math.round(v), lo), hi)
+}

--- a/src/lib/sprite-sheet/SpriteSheetUI.ts
+++ b/src/lib/sprite-sheet/SpriteSheetUI.ts
@@ -1,0 +1,573 @@
+import { SpriteSheetSettings, type DirectionEntry } from './SpriteSheetSettings.ts'
+import { SpriteSheetExporter } from './SpriteSheetExporter.ts'
+import { UI } from '../UI.ts'
+import { type Mesh2MotionEngine } from '../../Mesh2MotionEngine.ts'
+import {
+  type Scene,
+  type SkinnedMesh,
+  type AnimationMixer,
+  type AnimationClip,
+  WebGLRenderer,
+  PerspectiveCamera,
+  Vector3
+} from 'three'
+
+export class SpriteSheetUI {
+  private readonly settings: SpriteSheetSettings = new SpriteSheetSettings()
+  private readonly ui: UI = UI.getInstance()
+  private is_exporting: boolean = false
+  // The main 3D engine. We use it to read / write the main camera (OrbitControls
+  // target + position) and to render a live preview into our small canvas.
+  private readonly engine: Mesh2MotionEngine
+  // The preview uses its OWN WebGLRenderer bound to the small canvas, so we
+  // don't have to fight the main renderer's `preserveDrawingBuffer: false`
+  // (which makes drawImage(mainCanvas) return a black frame). The preview
+  // shares the main scene and the model's animations; only the camera +
+  // renderer are independent, so the user can keep orbiting the main view
+  // while the mini-canvas reflects the sprite sheet's pitch + distance.
+  private preview_renderer: WebGLRenderer | null = null
+  private preview_camera: PerspectiveCamera | null = null
+  private preview_animation_handle: number | null = null
+  private preview_last_render_ms: number = 0
+  private preview_direction_deg: number = 0
+
+  constructor (engine: Mesh2MotionEngine) {
+    this.engine = engine
+    this.settings.load()
+    this.build_direction_checkboxes()
+    this.sync_ui_from_settings()
+    this.add_event_listeners()
+    // Preview is always-on now. We defer the first start until the tab
+    // is visible — starting a WebGLRenderer against an offscreen canvas
+    // wastes GPU cycles and the panel may not have a size yet.
+    queueMicrotask(() => {
+      const panel = this.ui.dom_sidebar_panel_sprite_sheet
+      if (panel !== null && !panel.hidden) {
+        this.start_live_preview()
+      }
+    })
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Public API                                                         */
+  /* ------------------------------------------------------------------ */
+
+  /** Trigger the export. Called when the user clicks the in-panel "Export" button. */
+  public async do_export (
+    skinned_meshes: SkinnedMesh[],
+    clip: AnimationClip,
+    mixer: AnimationMixer,
+    scene: Scene
+  ): Promise<void> {
+    if (this.is_exporting) return
+    if (!skinned_meshes.length || !clip) {
+      console.warn('SpriteSheetUI: nothing to export')
+      return
+    }
+
+    this.is_exporting = true
+
+    // Stop live preview so we don't waste a frame before the export capture.
+    this.stop_live_preview()
+
+    // Pull latest values from UI
+    this.read_ui_into_settings()
+    this.settings.save()
+
+    const anim_name = clip.name.replace(/[^a-zA-Z0-9_-]/g, '_')
+
+    // Build sprite sheet
+    try {
+      const sheet_name = `spritesheet_${anim_name}_${this.settings.frame_width}x${this.settings.frame_height}`
+
+      const result = await SpriteSheetExporter.export(
+        skinned_meshes,
+        clip,
+        mixer,
+        this.settings,
+        scene,
+        (pct) => {
+          console.debug(`SpriteSheet export: ${Math.round(pct * 100)}%`)
+        }
+      )
+
+      // Download the PNG
+      const url = URL.createObjectURL(result.blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `${sheet_name}.png`
+      link.click()
+      URL.revokeObjectURL(url)
+
+      console.debug(
+        `SpriteSheet exported: ${result.total_width}x${result.total_height}, ` +
+        `${result.frame_count} frames x ${result.direction_count} directions`
+      )
+    } catch (err) {
+      console.error('SpriteSheet export failed:', err)
+    } finally {
+      this.is_exporting = false
+      // Restart preview so the panel keeps showing the model.
+      const panel = this.ui.dom_sidebar_panel_sprite_sheet
+      if (panel !== null && !panel.hidden) {
+        this.start_live_preview()
+      }
+    }
+  }
+
+  /** Re-read UI inputs into the in-memory settings. Called before exporting
+   *  and whenever an input fires (so the live preview reflects edits). */
+  public read_ui_into_settings (): void {
+    this.settings.sample_every_n_frames = this.num_value(this.ui.dom_ss_sample_every, 1)
+    this.settings.canvas_width = this.num_value(this.ui.dom_ss_canvas_width, 1024)
+    this.settings.canvas_height = this.num_value(this.ui.dom_ss_canvas_height, 1024)
+    this.settings.frame_width = this.num_value(this.ui.dom_ss_frame_width, 128)
+    this.settings.frame_height = this.num_value(this.ui.dom_ss_frame_height, 128)
+    this.settings.padding = this.num_value(this.ui.dom_ss_padding, 2)
+    this.settings.pitch_angle_degrees = this.num_value(this.ui.dom_ss_pitch_angle, 60)
+    this.settings.camera_distance = this.float_value(this.ui.dom_ss_camera_distance, 10)
+    if (this.ui.dom_ss_silhouette) {
+      this.settings.silhouette = this.ui.dom_ss_silhouette.checked
+    }
+    if (this.ui.dom_ss_one_row_per_direction) {
+      this.settings.one_row_per_direction = this.ui.dom_ss_one_row_per_direction.checked
+    }
+    if (this.ui.dom_ss_background_color) {
+      // color picker value is "#rrggbb" (or "#rgb" shorthand). parseInt
+      // happily ignores the leading "#" so we just take the substring.
+      const raw = this.ui.dom_ss_background_color.value.replace(/^#/, '').trim()
+      const expanded = raw.length === 3
+        ? raw.split('').map(c => c + c).join('')
+        : raw
+      const parsed = parseInt(expanded, 16)
+      if (Number.isFinite(parsed) && expanded.length === 6) {
+        this.settings.background_color = parsed
+      }
+    }
+
+    const cbs = this.get_dir_checkboxes()
+    for (const cb of cbs) {
+      const dir = this.settings.directions.find(d => d.id === cb.dataset.dirId)
+      if (dir) dir.enabled = cb.checked
+    }
+  }
+
+  /** Persist current settings to localStorage. */
+  public save_settings (): void {
+    this.settings.save()
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Internal                                                           */
+  /* ------------------------------------------------------------------ */
+
+  private build_direction_checkboxes (): void {
+    const grid = this.ui.dom_ss_direction_grid
+    if (!grid) return
+
+    grid.innerHTML = ''
+    for (const dir of this.settings.directions) {
+      const label = document.createElement('label')
+      label.className = 'direction-checkbox-label'
+
+      const cb = document.createElement('input')
+      cb.type = 'checkbox'
+      cb.id = `ss-dir-${dir.id}`
+      cb.checked = dir.enabled
+      cb.dataset.dirId = dir.id
+
+      const span = document.createElement('span')
+      span.textContent = dir.label
+
+      label.appendChild(cb)
+      label.appendChild(span)
+      grid.appendChild(label)
+    }
+  }
+
+  /** Push settings values into the DOM inputs. */
+  private sync_ui_from_settings (): void {
+    this.set_value(this.ui.dom_ss_sample_every, this.settings.sample_every_n_frames)
+    this.set_value(this.ui.dom_ss_canvas_width, this.settings.canvas_width)
+    this.set_value(this.ui.dom_ss_canvas_height, this.settings.canvas_height)
+    this.set_value(this.ui.dom_ss_frame_width, this.settings.frame_width)
+    this.set_value(this.ui.dom_ss_frame_height, this.settings.frame_height)
+    this.set_value(this.ui.dom_ss_padding, this.settings.padding)
+    this.set_value(this.ui.dom_ss_pitch_angle, this.settings.pitch_angle_degrees)
+    this.set_value_float(this.ui.dom_ss_camera_distance, this.settings.camera_distance)
+    if (this.ui.dom_ss_silhouette) {
+      this.ui.dom_ss_silhouette.checked = this.settings.silhouette
+    }
+    if (this.ui.dom_ss_one_row_per_direction) {
+      this.ui.dom_ss_one_row_per_direction.checked = this.settings.one_row_per_direction
+    }
+    if (this.ui.dom_ss_background_color) {
+      // Hex color picker value is "#RRGGBB"; settings stores the raw int.
+      this.ui.dom_ss_background_color.value = '#' + this.settings.background_color.toString(16).padStart(6, '0')
+    }
+
+    // Sync checkboxes
+    const cbs = this.get_dir_checkboxes()
+    for (const cb of cbs) {
+      cb.checked = this.settings.directions.find(d => d.id === cb.dataset.dirId)?.enabled ?? true
+    }
+  }
+
+  private add_event_listeners (): void {
+    // ----- Sidebar tab bar (Animations / Sprite Sheet) -----
+    // The Sprite Sheet settings used to live in a floating popup; now
+    // it's a full in-sidebar tab. These tabs control which panel is
+    // visible in the sidebar (only one at a time).
+    for (const tab of document.querySelectorAll<HTMLElement>('.sidebar-tab')) {
+      tab.addEventListener('click', (e) => {
+        const target = tab.dataset.tabTarget
+        if (target === 'animations' || target === 'sprite-sheet') {
+          this.switch_tab(target)
+        }
+      })
+    }
+
+    // Select All
+    this.ui.dom_ss_select_all?.addEventListener('click', () => {
+      this.set_all_directions(true)
+    })
+
+    // Select Cardinal only (S, N, E, W / 下上左右)
+    this.ui.dom_ss_select_cardinal?.addEventListener('click', () => {
+      this.set_cardinal_directions()
+    })
+
+    // Select Diagonal only (SW, NW, NE, SE / 右下右上左上左下)
+    this.ui.dom_ss_select_diagonal?.addEventListener('click', () => {
+      this.set_diagonal_directions()
+    })
+
+    // Reset defaults
+    this.ui.dom_ss_reset_defaults?.addEventListener('click', () => {
+      this.settings.reset_defaults()
+      this.sync_ui_from_settings()
+      this.settings.save()
+    })
+
+    // Export button inside the panel — kick off the actual export.
+    this.ui.dom_ss_apply_and_export?.addEventListener('click', () => {
+      this.read_ui_into_settings()
+      this.settings.save()
+      // Dispatch a custom event so the main bootstrap can pick it up
+      this.ui.dom_ss_apply_and_export?.dispatchEvent(
+        new CustomEvent('sprite-sheet-start-export', { bubbles: true })
+      )
+    })
+
+    // -------- Camera pitch / distance sync buttons --------
+    // These keep their Apply/Read semantics: Apply pushes the panel's
+    // pitch/distance values into the MAIN 3D viewport camera; Read pulls
+    // them back. The live preview always tracks the panel's values (no
+    // Apply needed for preview).
+    this.ui.dom_ss_pitch_apply?.addEventListener('click', () => {
+      this.read_ui_into_settings()
+      this.engine.set_camera_angles(this.settings.pitch_angle_degrees, this.settings.camera_distance)
+    })
+    this.ui.dom_ss_pitch_read?.addEventListener('click', () => {
+      const a = this.engine.get_camera_angles()
+      if (a === null) return
+      this.settings.pitch_angle_degrees = a.pitch_degrees
+      this.set_value(this.ui.dom_ss_pitch_angle, a.pitch_degrees)
+    })
+    this.ui.dom_ss_distance_apply?.addEventListener('click', () => {
+      this.read_ui_into_settings()
+      this.engine.set_camera_angles(this.settings.pitch_angle_degrees, this.settings.camera_distance)
+    })
+    this.ui.dom_ss_distance_read?.addEventListener('click', () => {
+      const a = this.engine.get_camera_angles()
+      if (a === null) return
+      this.settings.camera_distance = a.distance
+      this.set_value_float(this.ui.dom_ss_camera_distance, a.distance)
+    })
+
+    // -------- Live sync: input changes flow into settings --------
+    // Pitch / distance drive the preview camera + apply buttons.
+    // Canvas / frame / padding drive the exporter's layout math.
+    // Silhouette drives the exporter's material swap.
+    // Sample-every drives the exporter's frame skipping.
+    // We keep direction toggles out of this — they already write
+    // directly via their own checkbox change handlers below.
+    const live_inputs: Array<HTMLInputElement | null> = [
+      this.ui.dom_ss_sample_every,
+      this.ui.dom_ss_canvas_width,
+      this.ui.dom_ss_canvas_height,
+      this.ui.dom_ss_frame_width,
+      this.ui.dom_ss_frame_height,
+      this.ui.dom_ss_padding,
+      this.ui.dom_ss_pitch_angle,
+      this.ui.dom_ss_camera_distance,
+      this.ui.dom_ss_silhouette,
+      this.ui.dom_ss_one_row_per_direction,
+      this.ui.dom_ss_background_color
+    ]
+    for (const el of live_inputs) {
+      el?.addEventListener('input', () => {
+        this.read_ui_into_settings()
+        this.settings.save()
+      })
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Tab handling                                                       */
+  /* ------------------------------------------------------------------ */
+
+  /**
+   * Switch the sidebar's visible tab. The Sprite Sheet settings panel
+   * used to be a 380×612 floating popup — too cramped for the growing
+   * list of options. Now it's a dedicated sidebar tab, switched via
+   * the tab bar at the top of the sidebar.
+   *
+   * The preview render loop is started/stopped based on which tab is
+   * active so we don't burn GPU cycles when the user is looking at
+   * the Animations tab.
+   *
+   * @param target 'animations' (default landing) or 'sprite-sheet'
+   */
+  private switch_tab (target: 'animations' | 'sprite-sheet'): void {
+    // Update tabs
+    for (const tab of document.querySelectorAll<HTMLElement>('.sidebar-tab')) {
+      const is_active = tab.dataset.tabTarget === target
+      tab.classList.toggle('active', is_active)
+      tab.setAttribute('aria-selected', is_active ? 'true' : 'false')
+    }
+    // Update panels: show the active one, hide the other.
+    // We toggle `hidden` so screen readers / no-JS users still get
+    // the right semantic.
+    for (const panel of document.querySelectorAll<HTMLElement>('[data-tab-panel]')) {
+      const is_active = panel.dataset.tabPanel === target
+      panel.classList.toggle('active', is_active)
+      if (is_active) {
+        panel.removeAttribute('hidden')
+      } else {
+        panel.setAttribute('hidden', '')
+      }
+    }
+    // Start/stop preview based on which tab is active.
+    if (target === 'sprite-sheet') {
+      this.start_live_preview()
+    } else {
+      this.stop_live_preview()
+    }
+    // When switching to the sprite sheet tab, make sure the form reflects
+    // the latest saved settings (in case the user changed something
+    // externally since last open).
+    if (target === 'sprite-sheet') {
+      this.sync_ui_from_settings()
+    }
+  }
+
+  private set_all_directions (enabled: boolean): void {
+    const cbs = this.get_dir_checkboxes()
+    for (const cb of cbs) {
+      cb.checked = enabled
+      const dir = this.settings.directions.find(d => d.id === cb.dataset.dirId)
+      if (dir) dir.enabled = enabled
+    }
+    this.settings.save()
+  }
+
+  private set_cardinal_directions (): void {
+    this.settings.set_cardinal_only()
+    this.sync_dir_checkboxes_from_settings()
+    this.settings.save()
+  }
+
+  private set_diagonal_directions (): void {
+    this.settings.set_diagonal_only()
+    this.sync_dir_checkboxes_from_settings()
+    this.settings.save()
+  }
+
+  private sync_dir_checkboxes_from_settings (): void {
+    const cbs = this.get_dir_checkboxes()
+    for (const cb of cbs) {
+      const dir = this.settings.directions.find(d => d.id === cb.dataset.dirId)
+      cb.checked = dir?.enabled ?? true
+    }
+  }
+
+  /* ---- live preview in the small canvas ---- */
+
+  /**
+   * Start rendering the main 3D scene into the sidebar's small canvas using
+   * the sprite sheet's pitch + distance settings. Throttled to ~15 fps to
+   * keep the UI responsive while the user is fiddling with the inputs.
+   *
+   * Approach: instead of duplicating the entire WebGL renderer (which is
+   * expensive and brittle — the main scene has its own animation, lights,
+   * and OrbitControls), we sample the main renderer's canvas at the
+   * predicted sprite-sheet "capture" region. The main renderer's frame
+   * is already being drawn at 60fps by the engine's render loop, so the
+   * preview just copies a sub-region of it into the small canvas.
+   *
+   * Always-on: no start/stop button. The render loop is started when
+   * the user switches to the Sprite Sheet tab and stopped when they
+   * switch back.
+   */
+  private start_live_preview (): void {
+    if (this.preview_animation_handle !== null) return
+    const canvas = this.ui.dom_ss_preview_canvas
+    if (!canvas) return
+
+    // Set up a fresh, independent WebGLRenderer bound to the small canvas.
+    // We use this instead of drawImage(main_canvas) because the main
+    // renderer was created with preserveDrawingBuffer:false, so reading
+    // pixels back from it returns a black frame. Note: we explicitly set
+    // `preserveDrawingBuffer: true` here so drawImage(preview_canvas, ...)
+    // and readPixels() return the last rendered frame instead of zeros
+    // (the default of `false` causes the browser to clear the buffer after
+    // each composite, which makes a thumbnail / screenshot black).
+    try {
+      this.preview_renderer = new WebGLRenderer({
+        canvas,
+        antialias: true,
+        alpha: true,
+        preserveDrawingBuffer: true
+      })
+      this.preview_renderer.setPixelRatio(window.devicePixelRatio || 1)
+      this.preview_renderer.setSize(canvas.width, canvas.height, false)
+      this.preview_renderer.setClearColor(0x0d1b22, 1)
+    } catch (e) {
+      console.warn('sprite sheet preview: failed to create WebGLRenderer', e)
+      this.preview_renderer = null
+      this.stop_live_preview()
+      return
+    }
+
+    // Independent PerspectiveCamera. The main renderer's camera stays in
+    // whatever orbit position the user dragged it to — this one is driven
+    // entirely by the sprite sheet's pitch + distance.
+    this.preview_camera = new PerspectiveCamera(
+      45,
+      canvas.width / canvas.height,
+      0.1,
+      100
+    )
+
+    // Make sure the small canvas matches its displayed CSS size to its
+    // backing buffer — the panel max-height + scroll can resize it after open.
+    this.resize_preview_renderer_to_canvas()
+
+    const tick = (): void => {
+      this.preview_animation_handle = requestAnimationFrame(tick)
+      if (this.preview_renderer === null || this.preview_camera === null) return
+      const now = performance.now()
+      // Throttle to ~15 fps; the preview is a sanity check, not a live editor.
+      if (now - this.preview_last_render_ms < 60) return
+      this.preview_last_render_ms = now
+      this.render_preview_frame()
+    }
+    this.preview_animation_handle = requestAnimationFrame(tick)
+  }
+
+  private stop_live_preview (): void {
+    if (this.preview_animation_handle !== null) {
+      cancelAnimationFrame(this.preview_animation_handle)
+      this.preview_animation_handle = null
+    }
+    if (this.preview_renderer !== null) {
+      // Dispose the renderer's GL resources, but leave the canvas itself
+      // alone (it's a UI element, not owned by us).
+      this.preview_renderer.dispose()
+      this.preview_renderer = null
+    }
+    this.preview_camera = null
+    this.preview_last_render_ms = 0
+  }
+
+  /**
+   * Re-measure the preview canvas's CSS box and update the renderer to
+   * match. Called once at preview start and on window resize.
+   */
+  private resize_preview_renderer_to_canvas (): void {
+    if (this.preview_renderer === null) return
+    const canvas = this.ui.dom_ss_preview_canvas
+    if (canvas === null) return
+    const rect = canvas.getBoundingClientRect()
+    const w = Math.max(1, Math.round(rect.width))
+    const h = Math.max(1, Math.round(rect.height))
+    this.preview_renderer.setSize(w, h, false)
+    if (this.preview_camera !== null) {
+      this.preview_camera.aspect = w / h
+      this.preview_camera.updateProjectionMatrix()
+    }
+  }
+
+  /**
+   * One pass of the preview renderer: position the camera, then render the
+   * main scene. The scene contains the loaded model + skeleton helper, so
+   * we get the same look as the main viewport (modulo lighting + tone
+   * mapping; the preview renderer inherits three.js defaults, which is
+   * close enough for a sanity check).
+   */
+  private render_preview_frame (): void {
+    if (this.preview_renderer === null || this.preview_camera === null) return
+    const scene = this.engine.get_scene()
+    if (scene === null) return
+    // Lazily create / update the camera position based on the sprite sheet
+    // settings. We rotate the preview around the orbit target over time so
+    // the user actually sees the model from all sides without dragging.
+    this.update_preview_camera()
+    this.preview_renderer.render(scene, this.preview_camera)
+  }
+
+  /**
+   * Position the preview camera relative to the main scene's OrbitControls
+   * target. The preview always faces the target; the user's current orbit
+   * angle is ignored so the preview shows "front" by default and
+   * auto-rotates so the model is visible from all directions.
+   */
+  private update_preview_camera (): void {
+    if (this.preview_camera === null) return
+    const target = this.engine.get_camera_target()
+    const pitch_rad = (this.settings.pitch_angle_degrees * Math.PI) / 180
+    const distance = Math.max(0.5, this.settings.camera_distance)
+    const horizontal = distance * Math.cos(pitch_rad)
+    const vertical = distance * Math.sin(pitch_rad)
+    // Auto-rotate direction so the preview isn't a frozen frame.
+    this.preview_direction_deg = (this.preview_direction_deg + 0.6) % 360
+    const dir_rad = (this.preview_direction_deg * Math.PI) / 180
+    this.preview_camera.position.set(
+      target.x + horizontal * Math.sin(dir_rad),
+      target.y + vertical,
+      target.z + horizontal * Math.cos(dir_rad)
+    )
+    this.preview_camera.lookAt(target)
+    this.preview_camera.updateMatrixWorld(true)
+  }
+
+  /* ---- helpers ---- */
+
+  private get_dir_checkboxes (): HTMLInputElement[] {
+    if (!this.ui.dom_ss_direction_grid) return []
+    return Array.from(
+      this.ui.dom_ss_direction_grid.querySelectorAll('input[type="checkbox"]')
+    ) as HTMLInputElement[]
+  }
+
+  private num_value (el: HTMLInputElement | null, fallback: number): number {
+    if (!el) return fallback
+    const v = parseInt(el.value, 10)
+    return isNaN(v) ? fallback : v
+  }
+
+  private float_value (el: HTMLInputElement | null, fallback: number): number {
+    if (!el) return fallback
+    const v = parseFloat(el.value)
+    return isNaN(v) ? fallback : v
+  }
+
+  private set_value (el: HTMLInputElement | null, val: number): void {
+    if (el) el.value = String(val)
+  }
+
+  private set_value_float (el: HTMLInputElement | null, val: number): void {
+    if (el) el.value = val.toFixed(1)
+  }
+}

--- a/src/lib/sprite-sheet/sprite-sheet.css
+++ b/src/lib/sprite-sheet/sprite-sheet.css
@@ -1,0 +1,277 @@
+/* =============================================================
+   Sprite Sheet Settings Panel
+
+   USED TO BE: a 380×612 floating popup anchored to the toggle
+   button. That cramped everything because the settings have
+   outgrown the floating dialog (Sampling / Camera / Canvas &
+   Frame / Directions + always-on live preview + Export).
+
+   NOW: a full sidebar tab. The `.sprite-sheet-settings-panel`
+   lives inline inside `#sidebar-panel-sprite-sheet`. The tab bar
+   above decides which panel (.sidebar-tab-panel.active) is
+   visible. No more absolute positioning.
+   ============================================================= */
+
+/* ----- Sidebar tab bar (Animations / Sprite Sheet) ----- */
+.sidebar-tab-bar {
+  display: flex !important;
+  gap: 2px;
+  background: rgba(0, 0, 0, 0.25);
+  padding: 3px;
+  border-radius: 8px;
+  margin: 8px 0 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.sidebar-tab {
+  flex: 1 1 0;
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 7px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-alternate, #aaa);
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  user-select: none;
+}
+.sidebar-tab:hover {
+  color: var(--text-primary, #fff);
+  background: rgba(255, 255, 255, 0.05);
+}
+.sidebar-tab.active {
+  background: var(--button-primary-bg, rgb(175, 58, 190));
+  color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+}
+.sidebar-tab img {
+  filter: brightness(0) invert(1);
+  opacity: 0.85;
+}
+.sidebar-tab.active img {
+  opacity: 1;
+}
+
+/* ----- Tab panels ----- */
+.sidebar-tab-panel {
+  display: none !important;
+  width: 100%;
+  box-sizing: border-box;
+}
+.sidebar-tab-panel.active {
+  display: flex !important;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Sprite sheet settings panel — inline inside sidebar now */
+.sprite-sheet-settings-panel {
+  background: rgba(0, 0, 0, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 14px 12px;
+  width: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  /* No max-height / overflow — let the sidebar scroll itself. */
+}
+
+.sprite-sheet-settings-panel hr {
+  margin: 4px 0;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sprite-sheet-settings-panel .settings-section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-alternate, #aaa);
+  margin-bottom: 4px;
+  display: block;
+}
+
+.sprite-sheet-settings-panel .ss-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sprite-sheet-setting-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.sprite-sheet-setting-row label {
+  font-size: 13px;
+  white-space: nowrap;
+  color: var(--text-primary, #fff);
+}
+
+.sprite-sheet-setting-row input[type="number"] {
+  width: 72px;
+  padding: 3px 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  background: var(--bg-primary, #2b4353);
+  color: var(--text-primary, #fff);
+  font-size: 13px;
+  text-align: center;
+}
+
+/* Direction grid */
+.sprite-sheet-direction-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
+}
+
+.sprite-sheet-direction-grid .direction-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-primary, #fff);
+  transition: background 0.15s;
+  user-select: none;
+}
+
+.sprite-sheet-direction-grid .direction-checkbox-label:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.sprite-sheet-direction-grid .direction-checkbox-label input[type="checkbox"] {
+  accent-color: rgb(175, 58, 190);
+  margin: 0;
+}
+
+/* Button row at bottom — sticky so it stays visible without scrolling */
+.sprite-sheet-actions-row {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  position: sticky;
+  bottom: 0;
+  /* Solid background to cover settings scrolling underneath. Matches the
+     sidebar's gradient end color so it blends seamlessly. */
+  background: var(--bg-primary, #1a2e38);
+  padding: 8px 0 2px;
+  z-index: 10;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sprite-sheet-actions-row button {
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  background: var(--bg-primary, #2b4353);
+  color: var(--text-primary, #fff);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.sprite-sheet-actions-row button:hover {
+  background: var(--bg-tertiary, #7a97aa);
+}
+
+.sprite-sheet-actions-row button.primary-action {
+  background: var(--button-primary-bg, rgb(175, 58, 190));
+  border-color: var(--button-primary-bg, rgb(175, 58, 190));
+}
+
+.sprite-sheet-actions-row button.primary-action:hover {
+  background: rgba(175, 58, 190, 0.8);
+}
+
+/* Camera / sync inputs inside the panel */
+.sprite-sheet-settings-panel .ss-sync-input {
+  width: 64px;
+  text-align: right;
+}
+
+.sprite-sheet-settings-panel .ss-sync-btn {
+  background: var(--bg-primary, #2b4353);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text-primary, #fff);
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 14px;
+  line-height: 1.2;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+  min-width: 28px;
+}
+.sprite-sheet-settings-panel .ss-sync-btn:hover {
+  background: var(--bg-tertiary, #7a97aa);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+.sprite-sheet-settings-panel .ss-sync-btn:active {
+  transform: translateY(1px);
+}
+
+/* Inline toggle label (silhouette checkbox) */
+.sprite-sheet-settings-panel .ss-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-primary, #fff);
+  user-select: none;
+}
+.sprite-sheet-settings-panel .ss-toggle-label input[type="checkbox"] {
+  accent-color: rgb(175, 58, 190);
+  margin: 0;
+}
+
+/* Always-on live preview canvas (no start/stop button now). */
+.sprite-sheet-settings-panel .ss-preview-row {
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.sprite-sheet-settings-panel .ss-preview-canvas {
+  display: block;
+  background: #0d1b22;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  max-width: 200px;
+  margin: 0 auto;
+  image-rendering: pixelated;
+  /* The global `canvas { position: fixed; inset: 0 }` rule was pulling this
+     preview canvas to (0, 0) of the viewport. Force it to participate in
+     normal document flow inside the sprite sheet panel. */
+  position: static !important;
+  inset: auto !important;
+}
+
+
+/* =============================================================
+   Side-rail layout glue
+   The sidebar is built out of <span> elements (legacy), so the
+   container that wraps the new tab bar + panels can't be a real
+   flex/grid container by default. Force it to be one — this is
+   scoped tightly to not affect anything else.
+   ============================================================= */
+#skinned-step-animation-export-options {
+  display: block;
+  width: 100%;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -151,6 +151,9 @@ div, p {
 }
 
 #animation-listing-count {
+    position: absolute;
+    top: 0.3rem;
+    right: 1rem;
     color: var(--text-alternate)
 }
 
@@ -320,6 +323,14 @@ button:disabled {
     flex-wrap: wrap;
     align-items: center;
     gap: 0;
+    /* Sticky so the Download/Import buttons stay visible at the bottom
+       of the sidebar without needing to scroll to find them. */
+    position: sticky;
+    bottom: 0;
+    background: var(--bg-primary, #1a2e38);
+    padding: 8px 0 4px;
+    z-index: 10;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .download-combo {
@@ -454,6 +465,13 @@ option {
     overflow-y: auto;
     overflow-x: hidden;
     box-sizing: border-box;
+    /* Fixed sidebar width. Previously the sidebar width was set implicitly
+       by a hardcoded 24rem inside #animations-items, so children were
+       responsible for the parent's size. That left ~29px of dead space in
+       the list and made the sidebar explode if any child grew.
+       Now the sidebar owns its width (matching the previous implicit value)
+       and #animations-items fills it. */
+    width: 430px;
 }
 
 #animations-listing {
@@ -480,19 +498,13 @@ option {
     background: var(--bg-primary);
   }
 
-#toggle-select-all-container {
-    display: flex; 
-    gap: 1rem; 
-    align-items: center; 
-    justify-content: space-between;
-    margin-bottom: 0.5rem;
-}
+
 
 
 #animations-items{
-    max-height: calc(100vh - 22rem);
-    display: inline-flex;
-    overflow: auto;;
+    max-height: calc(100vh - 27rem);
+    display: flex;
+    overflow: auto;
     flex-direction: row;
     margin-bottom: 1rem;
     background: var(--bg-alternate);
@@ -500,12 +512,10 @@ option {
     gap: 0.25rem;
     flex-wrap: wrap;
     overflow-x: hidden;
-    width: 24rem; /* creates 3 column of animation items */
-}
-
-#animations-items.create-page {
-    /* create page has a tile at the top so we need this listing grid slightly smaller */
-     max-height: calc(100vh - 30rem);
+    /* Fill the sidebar width. Children flex to size columns automatically;
+       previously hardcoded 24rem left ~29px of dead space on the right. */
+    width: 100%;
+    box-sizing: border-box;
 }
 
 #animations-items div {
@@ -528,9 +538,13 @@ option {
 
     transition: box-shadow 0.2s ease-in-out;
 
-    /* specify dimensions helps grid layout without jumbling elements */
-    width: 103px;
-    height: 160px;
+    /* Three columns per row, each card = (container - 2 gaps) / 3.
+       min-width keeps cards readable if the sidebar ever gets too narrow.
+       flex-grow:0 prevents the last row's lone card from stretching to
+       fill the row (the "orphan card" bug). */
+    flex: 0 1 calc((100% - 0.5rem) / 3);
+    min-width: 80px;
+    min-height: 160px;
 }
 
 .anim-custom-item {
@@ -544,6 +558,19 @@ option {
     cursor: pointer;
     line-height: 110%;
     text-align: left;
+}
+
+/* Preview area fills the card width and keeps the original 100:120 aspect.
+   The video element itself has object-fit: contain so it scales without
+   stretching the character. */
+.anim-preview-placeholder {
+    width: 100%;
+    aspect-ratio: 100 / 120;
+}
+
+.anim-preview {
+    width: 100%;
+    height: 100%;
 }
 
 

--- a/static/images/icons/grid.svg
+++ b/static/images/icons/grid.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24">
+  <rect x="2" y="2" width="8" height="8" rx="1"/>
+  <rect x="14" y="2" width="8" height="8" rx="1"/>
+  <rect x="2" y="14" width="8" height="8" rx="1"/>
+  <rect x="14" y="14" width="8" height="8" rx="1"/>
+</svg>


### PR DESCRIPTION
## 概述

添加 sprite sheet 子系统到侧栏，包括完整的设置面板、实时预览和导出功能。

## 变更内容

### 核心文件（新增）
- `src/lib/sprite-sheet/SpriteSheetExporter.ts` — WebGL 渲染器导出精灵表为 PNG
- `src/lib/sprite-sheet/SpriteSheetSettings.ts` — 持久化配置（localStorage）
- `src/lib/sprite-sheet/SpriteSheetUI.ts` — 侧栏标签页 UI
- `src/lib/sprite-sheet/sprite-sheet.css` — 设置面板样式
- `src/lib/SceneEnvironmentManager.ts` — 渲染器生命周期管理
- `server.cjs` — 生产环境静态文件服务器

### 修改文件
- `src/create.html` / `src/index.html` — 侧栏标签页 HTML 结构
- `src/lib/EventListeners.ts` — sprite sheet 导出事件绑定
- `src/lib/UI.ts` — DOM 元素引用
- `src/lib/processes/animations-listing/` — 动画列表 UI 改进
- `src/Mesh2MotionEngine.ts` — SceneEnvironmentManager 集成
- `src/styles.css` — 侧栏通用样式

### 功能特性
- ✅ 侧栏 Sprite Sheet 标签页（替代旧的浮动弹窗）
- ✅ 实时预览画布（独立 WebGLRenderer）
- ✅ 采样频率、相机俯仰角/距离控制
- ✅ 画布/帧尺寸、内边距设置
- ✅ 剪影模式（黑底绿幕）
- ✅ 8 方向选择（All / Cardinal / Diagonal 快捷按钮）
- ✅ Flow / Legacy 布局模式（1 row per direction）
- ✅ 粘性底部操作按钮

## 验证
- ✅ `npm run build` 通过
- ✅ 页面加载无 JS 错误
- ✅ Sprite Sheet 标签页所有设置项可用
- ✅ CSS 正确打包到主 CSS bundle