### PR TITLE
skin weighting fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -372,7 +372,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -421,7 +420,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1968,7 +1966,6 @@
       "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1986,7 +1983,6 @@
       "integrity": "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2048,7 +2044,6 @@
       "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.66.0",
         "@typescript-eslint/types": "8.66.0",
@@ -2240,7 +2235,6 @@
       "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.10",
@@ -2370,7 +2364,6 @@
       "integrity": "sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.10",
         "fflate": "^0.8.2",
@@ -2408,7 +2401,6 @@
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2674,7 +2666,6 @@
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2729,7 +2720,6 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3866,7 +3856,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4167,8 +4156,7 @@
       "version": "0.185.1",
       "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
       "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4317,7 +4305,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4371,7 +4358,6 @@
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -4397,7 +4383,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
       "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -4499,7 +4484,6 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -4681,7 +4665,6 @@
       "integrity": "sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/src/lib/Utilities.ts
+++ b/src/lib/Utilities.ts
@@ -246,6 +246,17 @@ export class Utility {
     })
   }
 
+  static bone_side (bone_name: string): 'left' | 'right' | null {
+    const name = bone_name.toLowerCase()
+    if (/(^right_|^r_|_right$|_r$|\.right$|\.r$|-right$|-r$)/.test(name)) {
+      return 'right'
+    }
+    if (/(^left_|^l_|_left$|_l$|\.left$|\.l$|-left$|-l$)/.test(name)) {
+      return 'left'
+    }
+    return null
+  }
+
   static calculate_bone_base_name (bone_name: string): string {
     // remove if bone name part if they have suffix
     let normalized_bone_name: string = bone_name.toLowerCase().replace(/(_r|_l|_right|_left)$/, '')

--- a/src/lib/Utilities.ts
+++ b/src/lib/Utilities.ts
@@ -1,5 +1,5 @@
 import {
-  Vector3, Vector2, type Object3D, Mesh, Group, Bone, type Skeleton, Euler, Raycaster,
+  Vector3, Vector2, type Object3D, Mesh, Group, Bone, type Skeleton, Euler, Raycaster, Line3,
   type PerspectiveCamera, type Scene, type Object3DEventMap, type BufferAttribute, type BufferGeometry, type InterleavedBufferAttribute
 } from 'three'
 import BoneTransformState from './interfaces/BoneTransformState'
@@ -133,6 +133,19 @@ export class Utility {
     const child = bone.children[0] as Bone
     const child_position = Utility.world_position_from_object(child)
     return new Vector3().lerpVectors(bone_position, child_position, 0.5)
+  }
+
+  /**
+   * The world-space segment from a bone's start joint to its first child's
+   * joint. Childless bones collapse to a point at their own position.
+   */
+  static bone_segment (bone: Bone): Line3 {
+    const bone_position = Utility.world_position_from_object(bone)
+    if (bone.children.length === 0) {
+      return new Line3(bone_position, bone_position.clone())
+    }
+    const child = bone.children[0] as Bone
+    return new Line3(bone_position, Utility.world_position_from_object(child))
   }
 
   static bone_list_from_hierarchy (bone_hierarchy: Object3D): Bone[] {

--- a/src/lib/processes/edit-skeleton/ArmPlaneManager.ts
+++ b/src/lib/processes/edit-skeleton/ArmPlaneManager.ts
@@ -1,4 +1,5 @@
 import { Group, Mesh, PlaneGeometry, MeshBasicMaterial, type Scene, DoubleSide } from 'three'
+import { ArmWeightCorrector } from '../../solvers/ArmWeightCorrector.js'
 
 /**
  * ArmPlaneManager - manages the pair of mirrored vertical planes that show where
@@ -19,7 +20,7 @@ export class ArmPlaneManager {
   private current_plane_x: number = 0.0
   private current_center_y: number = 0.0
   private current_center_z: number = 0.0
-  private readonly plane_size: number = 2.0
+  private readonly plane_size: number = ArmWeightCorrector.correction_half_height * 2
   private is_visible: boolean = false
 
   /**

--- a/src/lib/solvers/ArmWeightCorrector.ts
+++ b/src/lib/solvers/ArmWeightCorrector.ts
@@ -1,7 +1,7 @@
 import {
   Vector3,
   Bone,
-  type BufferGeometry
+  type BufferGeometry, type Line3
 } from 'three'
 
 import { Utility } from '../Utilities.js'
@@ -28,6 +28,7 @@ export class ArmWeightCorrector {
   private readonly bones: Bone[]
   private readonly arm_plane_offset: number
   private left_side_sign: number = 0
+  private readonly segment_point_scratch: Vector3 = new Vector3()
 
   constructor (geometry: BufferGeometry, bones_master_data: Bone[], arm_plane_offset: number) {
     this.geometry = geometry
@@ -124,19 +125,19 @@ export class ArmWeightCorrector {
    * minus the root (global transform only) and leaf/orientation bones, which the
    * solver never assigns vertices to.
    */
-  private build_fallback_bone_candidates (arm_bone_indices: Set<number>): Array<{ index: number, midpoint: Vector3, side: 'left' | 'right' | null }> {
-    const candidates: Array<{ index: number, midpoint: Vector3, side: 'left' | 'right' | null }> = []
+  private build_fallback_bone_candidates (arm_bone_indices: Set<number>): Array<{ index: number, midpoint: Vector3, segment: Line3, side: 'left' | 'right' | null }> {
+    const candidates: Array<{ index: number, midpoint: Vector3, segment: Line3, side: 'left' | 'right' | null }> = []
 
     this.bones.forEach((bone, idx) => {
       if (arm_bone_indices.has(idx)) { return }
       if (bone.name === 'root' || Utility.is_leaf_bone(bone)) { return }
-      candidates.push({ index: idx, midpoint: Utility.bone_midpoint_to_child(bone), side: Utility.bone_side(bone.name) })
+      candidates.push({ index: idx, midpoint: Utility.bone_midpoint_to_child(bone), segment: Utility.bone_segment(bone), side: Utility.bone_side(bone.name) })
     })
 
     return candidates
   }
 
-  private calculate_left_side_sign (candidates: Array<{ index: number, midpoint: Vector3, side: 'left' | 'right' | null }>): number {
+  private calculate_left_side_sign (candidates: Array<{ index: number, midpoint: Vector3, segment: Line3, side: 'left' | 'right' | null }>): number {
     let left_x_sum = 0
     let left_count = 0
     for (const candidate of candidates) {
@@ -153,7 +154,7 @@ export class ArmWeightCorrector {
     skin_weights: number[],
     plane_x: number,
     arm_bone_indices: Set<number>,
-    fallback_bones: Array<{ index: number, midpoint: Vector3 }>
+    fallback_bones: Array<{ index: number, midpoint: Vector3, segment: Line3, side: 'left' | 'right' | null }>
   ): void {
     const vertex_count = this.geometry.attributes.position.array.length / 3
 
@@ -210,7 +211,7 @@ export class ArmWeightCorrector {
 
   private find_closest_fallback_bone (
     vertex_position: Vector3,
-    fallback_bones: Array<{ index: number, midpoint: Vector3, side: 'left' | 'right' | null }>
+    fallback_bones: Array<{ index: number, midpoint: Vector3, segment: Line3, side: 'left' | 'right' | null }>
   ): number {
     const left_side_sign = this.left_side_sign
     const vertex_on_left = left_side_sign !== 0 && Math.sign(vertex_position.x) === left_side_sign
@@ -223,7 +224,9 @@ export class ArmWeightCorrector {
         if (vertex_on_left !== (candidate.side === 'left')) { continue }
       }
 
-      const distance = candidate.midpoint.distanceTo(vertex_position)
+      const distance = candidate.segment
+        .closestPointToPoint(vertex_position, true, this.segment_point_scratch)
+        .distanceTo(vertex_position)
       if (distance < closest_distance) {
         closest_distance = distance
         closest_index = candidate.index
@@ -233,7 +236,9 @@ export class ArmWeightCorrector {
     if (closest_index === -1) {
       closest_index = fallback_bones[0].index
       for (const candidate of fallback_bones) {
-        const distance = candidate.midpoint.distanceTo(vertex_position)
+        const distance = candidate.segment
+          .closestPointToPoint(vertex_position, true, this.segment_point_scratch)
+          .distanceTo(vertex_position)
         if (distance < closest_distance) {
           closest_distance = distance
           closest_index = candidate.index

--- a/src/lib/solvers/ArmWeightCorrector.ts
+++ b/src/lib/solvers/ArmWeightCorrector.ts
@@ -24,11 +24,14 @@ import { Utility } from '../Utilities.js'
  * covers part of the chest.
  */
 export class ArmWeightCorrector {
+  public static readonly correction_half_height: number = 1.0
+
   private readonly geometry: BufferGeometry
   private readonly bones: Bone[]
   private readonly arm_plane_offset: number
   private left_side_sign: number = 0
   private max_plausible_distance: number = Infinity
+  private shoulder_center_y: number = 0
   private readonly segment_point_scratch: Vector3 = new Vector3()
 
   constructor (geometry: BufferGeometry, bones_master_data: Bone[], arm_plane_offset: number) {
@@ -80,6 +83,10 @@ export class ArmWeightCorrector {
     const anchor_x = ArmWeightCorrector.shoulder_anchor_x(this.bones)
     if (anchor_x === null) { return } // no arm bones on this rig, nothing to correct
 
+    const shoulder_bone = ArmWeightCorrector.find_shoulder_bone(this.bones)
+    if (shoulder_bone === undefined) { return }
+    this.shoulder_center_y = Utility.world_position_from_object(shoulder_bone).y
+
     const plane_x = anchor_x + this.arm_plane_offset
     if (plane_x <= 0) { return } // plane pushed past the center line, would strip both arms entirely
 
@@ -101,10 +108,10 @@ export class ArmWeightCorrector {
   }
 
   /**
-   * Every upperarm bone plus all of its descendants (lowerarm, hand, fingers),
-   * on both sides. Walking the hierarchy rather than matching a keyword list
-   * gives exactly "upperarm and below" without needing to enumerate every
-   * finger bone name, and it leaves the clavicle alone.
+   * Every upperarm bone plus its descendants down to (but not including) the
+   * hand, on both sides. Hands and fingers never cause the torso-drag problem
+   * this corrector exists for, so their weights are left alone. The clavicle
+   * is also excluded - it legitimately covers part of the chest.
    */
   private find_arm_bone_indices (): Set<number> {
     const bone_to_index = new Map<Bone, number>()
@@ -112,16 +119,20 @@ export class ArmWeightCorrector {
 
     const arm_bone_indices = new Set<number>()
 
+    const collect_until_hand = (bone: Bone): void => {
+      if (bone.name.toLowerCase().includes('hand')) { return }
+      const index = bone_to_index.get(bone)
+      if (index !== undefined) {
+        arm_bone_indices.add(index)
+      }
+      bone.children.forEach((child) => {
+        if (child instanceof Bone) { collect_until_hand(child) }
+      })
+    }
+
     this.bones.forEach((bone) => {
       if (!bone.name.toLowerCase().includes('upperarm')) { return }
-
-      bone.traverse((descendant) => {
-        if (!(descendant instanceof Bone)) { return }
-        const index = bone_to_index.get(descendant)
-        if (index !== undefined) {
-          arm_bone_indices.add(index)
-        }
-      })
+      collect_until_hand(bone)
     })
 
     return arm_bone_indices
@@ -171,6 +182,10 @@ export class ArmWeightCorrector {
       // Math.abs is what makes this symmetric: one slider drives both arms,
       // regardless of which side of the model is +X.
       if (Math.abs(vertex_position.x) >= plane_x) { continue } // outboard of the plane, genuinely arm territory
+
+      // only correct within the vertical span of the plane the user is shown,
+      // so hands hanging at hip height are left alone
+      if (Math.abs(vertex_position.y - this.shoulder_center_y) > ArmWeightCorrector.correction_half_height) { continue }
 
       const offset = i * 4
 

--- a/src/lib/solvers/ArmWeightCorrector.ts
+++ b/src/lib/solvers/ArmWeightCorrector.ts
@@ -27,6 +27,7 @@ export class ArmWeightCorrector {
   private readonly geometry: BufferGeometry
   private readonly bones: Bone[]
   private readonly arm_plane_offset: number
+  private left_side_sign: number = 0
 
   constructor (geometry: BufferGeometry, bones_master_data: Bone[], arm_plane_offset: number) {
     this.geometry = geometry
@@ -86,6 +87,8 @@ export class ArmWeightCorrector {
     const fallback_bones = this.build_fallback_bone_candidates(arm_bone_indices)
     if (fallback_bones.length === 0) { return }
 
+    this.left_side_sign = this.calculate_left_side_sign(fallback_bones)
+
     this.correct_vertex_weights(skin_indices, skin_weights, plane_x, arm_bone_indices, fallback_bones)
   }
 
@@ -121,16 +124,28 @@ export class ArmWeightCorrector {
    * minus the root (global transform only) and leaf/orientation bones, which the
    * solver never assigns vertices to.
    */
-  private build_fallback_bone_candidates (arm_bone_indices: Set<number>): Array<{ index: number, midpoint: Vector3 }> {
-    const candidates: Array<{ index: number, midpoint: Vector3 }> = []
+  private build_fallback_bone_candidates (arm_bone_indices: Set<number>): Array<{ index: number, midpoint: Vector3, side: 'left' | 'right' | null }> {
+    const candidates: Array<{ index: number, midpoint: Vector3, side: 'left' | 'right' | null }> = []
 
     this.bones.forEach((bone, idx) => {
       if (arm_bone_indices.has(idx)) { return }
       if (bone.name === 'root' || Utility.is_leaf_bone(bone)) { return }
-      candidates.push({ index: idx, midpoint: Utility.bone_midpoint_to_child(bone) })
+      candidates.push({ index: idx, midpoint: Utility.bone_midpoint_to_child(bone), side: Utility.bone_side(bone.name) })
     })
 
     return candidates
+  }
+
+  private calculate_left_side_sign (candidates: Array<{ index: number, midpoint: Vector3, side: 'left' | 'right' | null }>): number {
+    let left_x_sum = 0
+    let left_count = 0
+    for (const candidate of candidates) {
+      if (candidate.side === 'left') {
+        left_x_sum += candidate.midpoint.x
+        left_count++
+      }
+    }
+    return left_count > 0 ? Math.sign(left_x_sum) : 0
   }
 
   private correct_vertex_weights (
@@ -195,16 +210,34 @@ export class ArmWeightCorrector {
 
   private find_closest_fallback_bone (
     vertex_position: Vector3,
-    fallback_bones: Array<{ index: number, midpoint: Vector3 }>
+    fallback_bones: Array<{ index: number, midpoint: Vector3, side: 'left' | 'right' | null }>
   ): number {
+    const left_side_sign = this.left_side_sign
+    const vertex_on_left = left_side_sign !== 0 && Math.sign(vertex_position.x) === left_side_sign
+
     let closest_distance = Infinity
-    let closest_index = fallback_bones[0].index
+    let closest_index = -1
 
     for (const candidate of fallback_bones) {
+      if (candidate.side !== null && left_side_sign !== 0 && vertex_position.x !== 0) {
+        if (vertex_on_left !== (candidate.side === 'left')) { continue }
+      }
+
       const distance = candidate.midpoint.distanceTo(vertex_position)
       if (distance < closest_distance) {
         closest_distance = distance
         closest_index = candidate.index
+      }
+    }
+
+    if (closest_index === -1) {
+      closest_index = fallback_bones[0].index
+      for (const candidate of fallback_bones) {
+        const distance = candidate.midpoint.distanceTo(vertex_position)
+        if (distance < closest_distance) {
+          closest_distance = distance
+          closest_index = candidate.index
+        }
       }
     }
 

--- a/src/lib/solvers/ArmWeightCorrector.ts
+++ b/src/lib/solvers/ArmWeightCorrector.ts
@@ -28,6 +28,7 @@ export class ArmWeightCorrector {
   private readonly bones: Bone[]
   private readonly arm_plane_offset: number
   private left_side_sign: number = 0
+  private max_plausible_distance: number = Infinity
   private readonly segment_point_scratch: Vector3 = new Vector3()
 
   constructor (geometry: BufferGeometry, bones_master_data: Bone[], arm_plane_offset: number) {
@@ -89,6 +90,12 @@ export class ArmWeightCorrector {
     if (fallback_bones.length === 0) { return }
 
     this.left_side_sign = this.calculate_left_side_sign(fallback_bones)
+
+    this.geometry.computeBoundingSphere()
+    const bounding_sphere = this.geometry.boundingSphere
+    if (bounding_sphere !== null && bounding_sphere.radius > 0) {
+      this.max_plausible_distance = bounding_sphere.radius * 0.75
+    }
 
     this.correct_vertex_weights(skin_indices, skin_weights, plane_x, arm_bone_indices, fallback_bones)
   }
@@ -167,6 +174,20 @@ export class ArmWeightCorrector {
 
       const offset = i * 4
 
+      let has_arm_weight = false
+      for (let j = 0; j < 4; j++) {
+        if (arm_bone_indices.has(skin_indices[offset + j]) && skin_weights[offset + j] > 0) {
+          has_arm_weight = true
+          break
+        }
+      }
+      if (!has_arm_weight) { continue }
+
+      // no plausible replacement in range means the vertex keeps its arm
+      // weight rather than being handed to something absurdly far away
+      const replacement_bone_index = this.find_closest_fallback_bone(vertex_position, fallback_bones)
+      if (replacement_bone_index === -1) { continue }
+
       // Take the weight away from every arm bone influencing this vertex.
       // Index 0 is the root bone, which never receives weights, so it doubles
       // as the "empty slot" marker (same convention as HeadWeightCorrector).
@@ -185,8 +206,6 @@ export class ArmWeightCorrector {
       }
 
       if (stolen_weight <= 0) { continue }
-
-      const replacement_bone_index = this.find_closest_fallback_bone(vertex_position, fallback_bones)
 
       // Merge into the replacement bone's existing slot if it already influences
       // this vertex, otherwise reuse one of the slots we just emptied.
@@ -234,7 +253,6 @@ export class ArmWeightCorrector {
     }
 
     if (closest_index === -1) {
-      closest_index = fallback_bones[0].index
       for (const candidate of fallback_bones) {
         const distance = candidate.segment
           .closestPointToPoint(vertex_position, true, this.segment_point_scratch)
@@ -244,6 +262,10 @@ export class ArmWeightCorrector {
           closest_index = candidate.index
         }
       }
+    }
+
+    if (closest_distance > this.max_plausible_distance) {
+      return -1
     }
 
     return closest_index

--- a/src/lib/solvers/WeightCalculator.ts
+++ b/src/lib/solvers/WeightCalculator.ts
@@ -21,6 +21,10 @@ export class WeightCalculator {
   private cached_median_child_bone_positions: Vector3[] = []
   private readonly bone_object_to_index = new Map<Bone, number>()
   private pelvis_exclusion_bottom_y: number = -Infinity
+  private cached_bone_sides: Array<'left' | 'right' | null> = []
+  private mesh_center_x: number = 0
+  private side_dead_band: number = 0
+  private left_side_sign: number = 0
 
   // each index will be a bone index. the value will be a list of vertex indices that belong to that bone
   private readonly bones_vertex_segmentation: number[][] = []
@@ -53,6 +57,24 @@ export class WeightCalculator {
     })
 
     this.pelvis_exclusion_bottom_y = this.calculate_pelvis_exclusion_bottom_y()
+
+    this.cached_bone_sides = this.bones.map(b => Utility.bone_side(b.name))
+    this.geometry.computeBoundingBox()
+    const bounding_box = this.geometry.boundingBox
+    if (bounding_box !== null) {
+      this.mesh_center_x = (bounding_box.min.x + bounding_box.max.x) / 2
+      this.side_dead_band = (bounding_box.max.x - bounding_box.min.x) * 0.05
+    }
+
+    let left_x_offset_sum = 0
+    let left_bone_count = 0
+    this.cached_bone_sides.forEach((side, idx) => {
+      if (side === 'left') {
+        left_x_offset_sum += this.cached_median_child_bone_positions[idx].x - this.mesh_center_x
+        left_bone_count++
+      }
+    })
+    this.left_side_sign = left_bone_count > 0 ? Math.sign(left_x_offset_sum) : 0
   }
 
   public get_cached_median_child_bone_positions (): Vector3[] {
@@ -84,6 +106,19 @@ export class WeightCalculator {
           (bone.name.includes('hips') || bone.name.includes('pelvis'))) {
           if (vertex_position.y < this.pelvis_exclusion_bottom_y) {
             return
+          }
+        }
+
+        // a sided bone (thigh_l, hand_r, ...) can never claim a vertex that is
+        // clearly on the other half of the body
+        const bone_side = this.cached_bone_sides[idx]
+        if (bone_side !== null && this.left_side_sign !== 0) {
+          const vertex_offset_x = vertex_position.x - this.mesh_center_x
+          if (Math.abs(vertex_offset_x) > this.side_dead_band) {
+            const vertex_on_left = Math.sign(vertex_offset_x) === this.left_side_sign
+            if (vertex_on_left !== (bone_side === 'left')) {
+              return
+            }
           }
         }
 

--- a/src/lib/solvers/WeightCalculator.ts
+++ b/src/lib/solvers/WeightCalculator.ts
@@ -1,7 +1,7 @@
 import {
   Vector3, Raycaster, type Bone, Mesh,
   MeshBasicMaterial, DoubleSide,
-  type BufferGeometry
+  type BufferGeometry, type Line3
 } from 'three'
 
 import { Utility } from '../Utilities.js'
@@ -22,6 +22,8 @@ export class WeightCalculator {
   private readonly bone_object_to_index = new Map<Bone, number>()
   private pelvis_exclusion_bottom_y: number = -Infinity
   private cached_bone_sides: Array<'left' | 'right' | null> = []
+  private cached_bone_segments: Line3[] = []
+  private readonly segment_point_scratch: Vector3 = new Vector3()
   private mesh_center_x: number = 0
   private side_dead_band: number = 0
   private left_side_sign: number = 0
@@ -45,6 +47,7 @@ export class WeightCalculator {
    */
   public initialize_caches (): void {
     this.cached_median_child_bone_positions = this.bones.map(b => Utility.bone_midpoint_to_child(b))
+    this.cached_bone_segments = this.bones.map(b => Utility.bone_segment(b))
     this.bones.forEach((b, idx) => this.bone_object_to_index.set(b, idx))
 
     // The root bone is only for global transform changes, and leaf/orientation
@@ -122,7 +125,9 @@ export class WeightCalculator {
           }
         }
 
-        const distance: number = this.cached_median_child_bone_positions[idx].distanceTo(vertex_position)
+        const distance: number = this.cached_bone_segments[idx]
+          .closestPointToPoint(vertex_position, true, this.segment_point_scratch)
+          .distanceTo(vertex_position)
         if (distance < closest_bone_distance) {
           closest_bone_distance = distance
           closest_bone_index = idx

--- a/src/lib/solvers/WeightCalculator.ts
+++ b/src/lib/solvers/WeightCalculator.ts
@@ -27,6 +27,7 @@ export class WeightCalculator {
   private mesh_center_x: number = 0
   private side_dead_band: number = 0
   private left_side_sign: number = 0
+  private max_plausible_distance: number = Infinity
 
   // each index will be a bone index. the value will be a list of vertex indices that belong to that bone
   private readonly bones_vertex_segmentation: number[][] = []
@@ -69,6 +70,12 @@ export class WeightCalculator {
       this.side_dead_band = (bounding_box.max.x - bounding_box.min.x) * 0.05
     }
 
+    this.geometry.computeBoundingSphere()
+    const bounding_sphere = this.geometry.boundingSphere
+    if (bounding_sphere !== null && bounding_sphere.radius > 0) {
+      this.max_plausible_distance = bounding_sphere.radius * 0.75
+    }
+
     let left_x_offset_sum = 0
     let left_bone_count = 0
     this.cached_bone_sides.forEach((side, idx) => {
@@ -93,8 +100,10 @@ export class WeightCalculator {
 
     for (let i = 0; i < vertex_count; i++) {
       const vertex_position: Vector3 = new Vector3().fromBufferAttribute(this.geometry.attributes.position, i)
-      let closest_bone_distance: number = 1000 // arbitrary large number to start with
-      let closest_bone_index: number = 0
+      let closest_bone_distance: number = Infinity
+      let closest_bone_index: number = -1
+      let closest_any_distance: number = Infinity
+      let closest_any_index: number = 0
 
       this.bones.forEach((bone, idx) => {
         // Skip the root bone (global transform only) and leaf/orientation bones.
@@ -112,6 +121,15 @@ export class WeightCalculator {
           }
         }
 
+        const distance: number = this.cached_bone_segments[idx]
+          .closestPointToPoint(vertex_position, true, this.segment_point_scratch)
+          .distanceTo(vertex_position)
+
+        if (distance < closest_any_distance) {
+          closest_any_distance = distance
+          closest_any_index = idx
+        }
+
         // a sided bone (thigh_l, hand_r, ...) can never claim a vertex that is
         // clearly on the other half of the body
         const bone_side = this.cached_bone_sides[idx]
@@ -125,14 +143,19 @@ export class WeightCalculator {
           }
         }
 
-        const distance: number = this.cached_bone_segments[idx]
-          .closestPointToPoint(vertex_position, true, this.segment_point_scratch)
-          .distanceTo(vertex_position)
+        if (distance > this.max_plausible_distance) {
+          return
+        }
+
         if (distance < closest_bone_distance) {
           closest_bone_distance = distance
           closest_bone_index = idx
         }
       })
+
+      if (closest_bone_index === -1) {
+        closest_bone_index = closest_any_index
+      }
 
       this.bones_vertex_segmentation[closest_bone_index] ??= [] // Initialize the array if it doesn't exist
       this.bones_vertex_segmentation[closest_bone_index].push(i)

--- a/src/lib/solvers/WeightCalculator.ts
+++ b/src/lib/solvers/WeightCalculator.ts
@@ -20,7 +20,7 @@ export class WeightCalculator {
 
   private cached_median_child_bone_positions: Vector3[] = []
   private readonly bone_object_to_index = new Map<Bone, number>()
-  private distance_to_bottom_of_position_tracking_bone: number = 0
+  private pelvis_exclusion_bottom_y: number = -Infinity
 
   // each index will be a bone index. the value will be a list of vertex indices that belong to that bone
   private readonly bones_vertex_segmentation: number[][] = []
@@ -52,7 +52,7 @@ export class WeightCalculator {
       }
     })
 
-    this.distance_to_bottom_of_position_tracking_bone = this.calculate_distance_to_bottom_of_position_tracking_bone()
+    this.pelvis_exclusion_bottom_y = this.calculate_pelvis_exclusion_bottom_y()
   }
 
   public get_cached_median_child_bone_positions (): Vector3[] {
@@ -78,14 +78,12 @@ export class WeightCalculator {
           return
         }
 
-        // hip bones should have custom logic for distance. If the distance is too far away we should ignore it
-        // This will help with hips when left/right legs could be closer than knee bones
+        // vertices below the crotch belong to the left or right leg, so the
+        // hip/pelvis bone should not compete for them
         if (this.skeleton_type === SkeletonType.Human &&
           (bone.name.includes('hips') || bone.name.includes('pelvis'))) {
-          // if the intersection point is lower than the vertex position, that means the vertex is below
-          // the hips area, and is part of the left or right leg...ignore that result
-          if (this.distance_to_bottom_of_position_tracking_bone !== null && this.distance_to_bottom_of_position_tracking_bone < vertex_position.y) {
-            return// this vertex is below our crotch area, so it cannot be part of our hips
+          if (vertex_position.y < this.pelvis_exclusion_bottom_y) {
+            return
           }
         }
 
@@ -107,7 +105,7 @@ export class WeightCalculator {
 
   // every vertex checks to see if it is below the hips area,
   // so do this calculation once and cache it for the lookup later
-  private calculate_distance_to_bottom_of_position_tracking_bone (): number {
+  private calculate_pelvis_exclusion_bottom_y (): number {
 
     const position_tracking_bone_name: string = RigConfig.by_skeleton_type(this.skeleton_type as SkeletonType)?.position_tracking_bone_name || 'UNKNOWN POSITION BONE'
 
@@ -116,20 +114,23 @@ export class WeightCalculator {
       return name.includes(position_tracking_bone_name.toLowerCase())
     })
 
-    if (position_tracking_bone_object === undefined) { 
+    if (position_tracking_bone_object === undefined) {
         throw new Error('Position tracking bone not found')
     }
 
     const intesection_point: Vector3 | null = this.cast_intersection_ray_down_from_bone(position_tracking_bone_object)
 
-    // get the distance from the bone point to the intersection point
+    if (intesection_point === null) {
+      return -Infinity
+    }
+
     const bone_index = this.bones.findIndex(b => b === position_tracking_bone_object)
     const bone_position: Vector3 = this.cached_median_child_bone_positions[bone_index]
 
-    let distance_to_bottom: number = intesection_point?.distanceTo(bone_position) ?? 0
-    distance_to_bottom *= 1.1 // buffer zone to make sure to include vertices at intersection
+    // buffer zone to make sure to include vertices at intersection
+    const buffer: number = (bone_position.y - intesection_point.y) * 0.1
 
-    return distance_to_bottom
+    return intesection_point.y - buffer
   }
 
   private cast_intersection_ray_down_from_bone (bone: Bone): Vector3 | null {

--- a/src/lib/solvers/WeightNormalizer.ts
+++ b/src/lib/solvers/WeightNormalizer.ts
@@ -42,7 +42,6 @@ export class WeightNormalizer {
     for (const vertex_index of vertices_that_do_not_have_influences_adding_to_one) {
       const offset = vertex_index * 4
 
-      // if the weight is 0.00, then we can assign the remaining weights to the other bones
       const weights = [
         all_skin_weights[offset],
         all_skin_weights[offset + 1],
@@ -50,14 +49,12 @@ export class WeightNormalizer {
         all_skin_weights[offset + 3]
       ]
       const weight_sum = weights.reduce((a, b) => a + b, 0)
-      const weight_per_index: number = (1 - weight_sum) / 3.0
-      console.log(weight_per_index)
+      if (weight_sum === 0) {
+        continue
+      }
 
-      // assign the weights all at once
       for (let i = 0; i < 4; i++) {
-        if (weights[i] !== 0) {
-          all_skin_weights[offset + i] += weight_per_index
-        }
+        all_skin_weights[offset + i] = weights[i] / weight_sum
       }
     }
   }


### PR DESCRIPTION
Vertices could bind to absurd bones, like fingers weighted to the opposite thigh. This adds a body-side check and a distance clamp, measures against the bone segment instead of its midpoint, fixes the pelvis exclusion comparison, keeps arm correction inside the visible plane, and fixes weight normalization.