### PR TITLE
scale animations by hip height ratio

### DIFF
--- a/src/lib/processes/animations-listing/AnimationLoader.ts
+++ b/src/lib/processes/animations-listing/AnimationLoader.ts
@@ -1,5 +1,5 @@
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
-import { type AnimationClip } from 'three'
+import { type AnimationClip, type Object3D, type SkinnedMesh } from 'three'
 import { AnimationUtility } from './AnimationUtility.ts'
 import { type SkeletonType } from '../../enums/SkeletonType.ts'
 import { RigConfig } from '../../RigConfig.ts'
@@ -156,7 +156,8 @@ export class AnimationLoader extends EventTarget {
   public async load_animations_from_file (
     file: File,
     skeleton_scale: number = 1.0,
-    metadata_override: Partial<AnimationClipMetadata> = {}
+    metadata_override: Partial<AnimationClipMetadata> = {},
+    target_skinned_mesh: SkinnedMesh | null = null
   ): Promise<TransformedAnimationClipPair[]> {
     const file_url = URL.createObjectURL(file)
     const file_total = file.size > 0 ? file.size : 1
@@ -188,7 +189,7 @@ export class AnimationLoader extends EventTarget {
 
             const processed_clips = this.process_loaded_animations(
               animations,
-              skeleton_scale,
+              this.calculate_import_scale(gltf.scene, skeleton_scale, target_skinned_mesh),
               metadata_override
             )
             resolve(processed_clips)
@@ -220,6 +221,31 @@ export class AnimationLoader extends EventTarget {
         }
       )
     })
+  }
+
+  /**
+   * The blind skeleton_scale multiplier assumes imported clips are authored at
+   * the reference rig's scale. A file that ships its own armature (including a
+   * model previously exported from this app) tells us its actual scale, so use
+   * the ratio of the current rig's hip height to the file's hip height instead.
+   */
+  private calculate_import_scale (
+    imported_scene: Object3D | null | undefined,
+    skeleton_scale: number,
+    target_skinned_mesh: SkinnedMesh | null
+  ): number {
+    if (imported_scene === null || imported_scene === undefined || target_skinned_mesh === null) {
+      return skeleton_scale
+    }
+
+    const current_hips_height = AnimationUtility.bind_pose_hips_height(target_skinned_mesh)
+    const imported_hips_height = AnimationUtility.rest_hips_height_from_scene(imported_scene)
+
+    if (current_hips_height === null || imported_hips_height === null) {
+      return skeleton_scale
+    }
+
+    return current_hips_height / imported_hips_height
   }
 
   /**

--- a/src/lib/processes/animations-listing/AnimationUtility.scaling.test.ts
+++ b/src/lib/processes/animations-listing/AnimationUtility.scaling.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { Bone, Matrix4, Object3D, Scene, Skeleton, SkinnedMesh, BufferGeometry } from 'three'
+import { AnimationUtility } from './AnimationUtility'
+
+function build_armature (hips_height: number): { root: Bone, hips: Bone } {
+  const root = new Bone()
+  root.name = 'root'
+  const hips = new Bone()
+  hips.name = 'pelvis'
+  hips.position.set(0, hips_height, 0)
+  root.add(hips)
+  root.updateWorldMatrix(true, true)
+  return { root, hips }
+}
+
+describe('AnimationUtility hip height helpers', () => {
+  it('reads the bind pose hip height from a skinned mesh', () => {
+    const { root, hips } = build_armature(1.5)
+    const skeleton = new Skeleton([root, hips])
+    const mesh = new SkinnedMesh(new BufferGeometry())
+    mesh.add(root)
+    mesh.bind(skeleton, new Matrix4())
+
+    expect(AnimationUtility.bind_pose_hips_height(mesh)).toBeCloseTo(1.5)
+  })
+
+  it('returns null when the rig has no hips bone', () => {
+    const root = new Bone()
+    root.name = 'root'
+    const skeleton = new Skeleton([root])
+    const mesh = new SkinnedMesh(new BufferGeometry())
+    mesh.add(root)
+    mesh.bind(skeleton, new Matrix4())
+
+    expect(AnimationUtility.bind_pose_hips_height(mesh)).toBeNull()
+  })
+
+  it('reads the rest hip height from an imported scene, including armature scale', () => {
+    const { root } = build_armature(1.0)
+    const armature = new Object3D()
+    armature.add(root)
+    armature.scale.set(2, 2, 2)
+    const scene = new Scene()
+    scene.add(armature)
+
+    expect(AnimationUtility.rest_hips_height_from_scene(scene)).toBeCloseTo(2.0)
+  })
+
+  it('returns null for a scene without bones', () => {
+    const scene = new Scene()
+    scene.add(new Object3D())
+    expect(AnimationUtility.rest_hips_height_from_scene(scene)).toBeNull()
+  })
+})

--- a/src/lib/processes/animations-listing/AnimationUtility.ts
+++ b/src/lib/processes/animations-listing/AnimationUtility.ts
@@ -1,8 +1,44 @@
-import { AnimationClip, Quaternion, Vector3, type KeyframeTrack, type QuaternionKeyframeTrack } from 'three'
+import { AnimationClip, Matrix4, Quaternion, Vector3, type KeyframeTrack, type QuaternionKeyframeTrack, type Object3D, type SkinnedMesh, type Bone } from 'three'
 import type { TransformedAnimationClipPair } from './interfaces/TransformedAnimationClipPair'
 import { RigConfig } from '../../RigConfig'
 
 export class AnimationUtility {
+  // rest-pose hip height of the rig a skinned mesh is bound to, read from the
+  // bind matrices so a currently playing animation cannot skew it
+  static bind_pose_hips_height (skinned_mesh: SkinnedMesh): number | null {
+    const skeleton = skinned_mesh.skeleton
+    const hips_index = skeleton.bones.findIndex((bone) => {
+      const name = bone.name.toLowerCase()
+      return name.includes('hips') || name.includes('pelvis')
+    })
+    if (hips_index === -1 || skeleton.boneInverses[hips_index] === undefined) {
+      return null
+    }
+    const bind_matrix = new Matrix4().copy(skeleton.boneInverses[hips_index]).invert()
+    const height = Math.abs(new Vector3().setFromMatrixPosition(bind_matrix).y)
+    return height > 0 ? height : null
+  }
+
+  // rest-pose hip height of whatever armature ships inside an imported file
+  static rest_hips_height_from_scene (scene: Object3D): number | null {
+    let hips_bone: Object3D | null = null
+    scene.updateMatrixWorld(true)
+    scene.traverse((object) => {
+      if (hips_bone !== null || !((object as Bone).isBone ?? false)) {
+        return
+      }
+      const name = object.name.toLowerCase()
+      if (name.includes('hips') || name.includes('pelvis')) {
+        hips_bone = object
+      }
+    })
+    if (hips_bone === null) {
+      return null
+    }
+    const height = Math.abs(new Vector3().setFromMatrixPosition((hips_bone as Object3D).matrixWorld).y)
+    return height > 0 ? height : null
+  }
+
   // when we scaled the skeleton itself near the beginning, we kept track of that
   // this scaling will affect position keyframes since they expect the original skeleton scale
   // this will fix any issues with position keyframes not matching the current skeleton scale

--- a/src/lib/processes/animations-listing/CustomAnimationImporter.ts
+++ b/src/lib/processes/animations-listing/CustomAnimationImporter.ts
@@ -117,7 +117,8 @@ export class CustomAnimationImporter extends EventTarget {
       const new_animation_clips = await this.animation_loader.load_animations_from_file(
         file,
         this.skeleton_scale,
-        metadata_override
+        metadata_override,
+        this.skinned_meshes_to_animate[0] ?? null
       )
 
       // Validate custom animations against our target skeleton

--- a/src/retarget/AnimationRetargetService.ts
+++ b/src/retarget/AnimationRetargetService.ts
@@ -4,6 +4,7 @@ import {
   type Skeleton
 } from 'three'
 import { RetargetUtils, type TrackNameParts, type BoneRestTransform } from './RetargetUtils.ts'
+import { Utility } from '../lib/Utilities.ts'
 import { TargetBoneMappingType } from './steps/StepBoneMapping.ts'
 import { SkeletonType } from '../lib/enums/SkeletonType.ts'
 import { Retargeter } from './human-retargeting/Retargeter.ts'
@@ -156,6 +157,11 @@ export class AnimationRetargetService {
 
     const reverse_mappings = RetargetUtils.reverse_bone_mapping(this.bone_mappings)
 
+    // even a same-named rig (a re-imported Mesh2Motion export) is usually a
+    // scaled copy of the reference skeleton, so root motion and hip height in
+    // the position tracks have to be rescaled to the target's proportions
+    const position_scale_delta = this.calculate_position_scale_delta()
+
     // Process each track in the source animation
     source_clip.tracks.forEach((track) => {
       // Parse the track name to get the bone name and property
@@ -187,6 +193,11 @@ export class AnimationRetargetService {
           const new_track = new QuaternionKeyframeTrack(new_track_name, times_copy, values_copy)
           new_tracks.push(new_track)
         } else if (track_property === 'position' || track_property === 'scale') {
+          if (track_property === 'position' && position_scale_delta !== 1) {
+            for (let i = 0; i < values_copy.length; i++) {
+              values_copy[i] *= position_scale_delta
+            }
+          }
           const new_track = new VectorKeyframeTrack(new_track_name, times_copy, values_copy)
           new_tracks.push(new_track)
         } else {
@@ -205,6 +216,50 @@ export class AnimationRetargetService {
   // #endregion
 
   // #region PRIVATE METHODS
+
+  private calculate_position_scale_delta (): number {
+    if (this.target_skinned_meshes.length === 0) {
+      return 1
+    }
+
+    const source_skeleton: Skeleton | null = RetargetUtils.create_skeleton_from_group_object(this.source_armature)
+    if (source_skeleton === null) {
+      return 1
+    }
+
+    const target_rest_skeleton: Skeleton =
+      RetargetUtils.clone_skeleton(this.target_skinned_meshes[0].skeleton, this.target_rest_transforms)
+
+    const source_height = AnimationRetargetService.hips_rest_height(source_skeleton)
+    const target_height = AnimationRetargetService.hips_rest_height(target_rest_skeleton)
+
+    if (!Number.isFinite(source_height) || !Number.isFinite(target_height) ||
+      source_height <= 0 || target_height <= 0) {
+      return 1
+    }
+
+    return target_height / source_height
+  }
+
+  private static hips_rest_height (skeleton: Skeleton): number {
+    const hips_bone = skeleton.bones.find((bone) => {
+      const name = bone.name.toLowerCase()
+      return name.includes('hips') || name.includes('pelvis')
+    })
+
+    if (hips_bone !== undefined) {
+      return Math.abs(Utility.world_position_from_object(hips_bone).y)
+    }
+
+    let min_y = Infinity
+    let max_y = -Infinity
+    skeleton.bones.forEach((bone) => {
+      const world_y = Utility.world_position_from_object(bone).y
+      min_y = Math.min(min_y, world_y)
+      max_y = Math.max(max_y, world_y)
+    })
+    return max_y - min_y
+  }
 
   private apply_human_swing_twist_retargeting (source_clip: AnimationClip): AnimationClip {
     // the retargeter needs Skeleton inputs for both source and target.


### PR DESCRIPTION
Retargeting onto a rig with Mesh2Motion bone names copied position tracks unscaled, and re-importing an exported animation applied skeleton scale twice. Both paths now scale positions by measured hip height.