### PR TITLE
undo improvements

### DIFF
--- a/src/lib/EventListeners.ts
+++ b/src/lib/EventListeners.ts
@@ -315,9 +315,6 @@ export class EventListeners {
 
       // reset current bone selection for edit skeleton step
       this.bootstrap.edit_skeleton_step.set_currently_selected_bone(null)
-
-      // reset the undo/redo system
-      this.bootstrap.edit_skeleton_step.clear_undo_history()
     })
 
     // going back to load skeleton step from edit skeleton step

--- a/src/lib/EventListeners.ts
+++ b/src/lib/EventListeners.ts
@@ -3,7 +3,6 @@ import { ModelPreviewDisplay } from './enums/ModelPreviewDisplay'
 import { ProcessStep } from './enums/ProcessStep'
 import { TransformSpace } from './enums/TransformSpace'
 import { Utility } from './Utilities'
-import { ModelCleanupUtility } from './processes/load-model/ModelCleanupUtility'
 import { ModelAnalysisReport } from './processes/load-model/ModelAnalysisReport'
 import { DownloadSuccessDialog } from './components/download-success/DownloadSuccessDialog'
 import { ModalDialog } from './ModalDialog.ts'
@@ -233,15 +232,15 @@ export class EventListeners {
 
     // rotate model after loading it in to orient it correctly
     this.bootstrap.ui.dom_rotate_model_x_button?.addEventListener('click', () => {
-      ModelCleanupUtility.rotate_model_geometry(this.bootstrap.load_model_step.model_meshes(), 'x', 90)
+      this.bootstrap.load_model_step.rotate_model('x')
     })
 
     this.bootstrap.ui.dom_rotate_model_y_button?.addEventListener('click', () => {
-      ModelCleanupUtility.rotate_model_geometry(this.bootstrap.load_model_step.model_meshes(), 'y', 90)
+      this.bootstrap.load_model_step.rotate_model('y')
     })
 
     this.bootstrap.ui.dom_rotate_model_z_button?.addEventListener('click', () => {
-      ModelCleanupUtility.rotate_model_geometry(this.bootstrap.load_model_step.model_meshes(), 'z', 90)
+      this.bootstrap.load_model_step.rotate_model('z')
     })
 
     // show a breakdown of what was found in the imported file
@@ -256,16 +255,7 @@ export class EventListeners {
 
     // Auto-align model to floor
     this.bootstrap.ui.dom_auto_align_model_button?.addEventListener('click', () => {
-      // move the mesh geometry data to the floor
-      const mesh_data = this.bootstrap.load_model_step.model_meshes()
-      ModelCleanupUtility.move_model_to_floor(mesh_data)
-
-      // move the transform widget to reset it to the new position on the canvas
-      const py = mesh_data.position.y
-      if (py !== 0) {
-        ModelCleanupUtility.translate_model_vertices(mesh_data, 0, py, 0)
-        mesh_data.position.setY(0)
-      }
+      this.bootstrap.load_model_step.auto_align_model_to_floor()
     })
 
     this.bootstrap.ui.dom_show_skeleton_checkbox?.addEventListener('click', (event: MouseEvent) => {
@@ -368,16 +358,27 @@ export class EventListeners {
 
     // Keyboard shortcuts for undo/redo
     document.addEventListener('keydown', (event: KeyboardEvent) => {
-      // Only handle keyboard shortcuts when in EditSkeleton step
-      if (this.bootstrap.process_step !== ProcessStep.EditSkeleton) {
-        return
-      }
-
       // Define undo/redo shortcut conditions
       // Ctrl+Z or Cmd+Z for undo
       // Ctrl+Y, Cmd+Y, Ctrl+Shift+Z, or Cmd+Shift+Z for redo
       const is_undo_shortcut_pressed = (event.ctrlKey || event.metaKey) && event.key === 'z' && !event.shiftKey
       const is_redo_shortcut_pressed = (event.ctrlKey || event.metaKey) && (event.key === 'y' || (event.key === 'z' && event.shiftKey))
+
+      if (this.bootstrap.process_step === ProcessStep.LoadSkeleton) {
+        if (is_undo_shortcut_pressed) {
+          event.preventDefault()
+          this.bootstrap.load_model_step.undo_model_transform()
+        }
+        if (is_redo_shortcut_pressed) {
+          event.preventDefault()
+          this.bootstrap.load_model_step.redo_model_transform()
+        }
+        return
+      }
+
+      if (this.bootstrap.process_step !== ProcessStep.EditSkeleton) {
+        return
+      }
 
       if (is_undo_shortcut_pressed) {
         event.preventDefault()

--- a/src/lib/Utilities.ts
+++ b/src/lib/Utilities.ts
@@ -1,5 +1,5 @@
 import {
-  Vector3, Vector2, type Object3D, Mesh, Group, Bone, type Skeleton, Euler, Raycaster,
+  Vector3, Vector2, type Object3D, Mesh, Group, Bone, type Skeleton, Raycaster,
   type PerspectiveCamera, type Scene, type Object3DEventMap, type BufferAttribute, type BufferGeometry, type InterleavedBufferAttribute
 } from 'three'
 import BoneTransformState from './interfaces/BoneTransformState'
@@ -213,12 +213,10 @@ export class Utility {
   static store_bone_transforms (skeleton: Skeleton): BoneTransformState[] {
     const bone_transforms: BoneTransformState[] = []
     skeleton.bones.forEach((bone: Bone) => {
-      const new_rotation: Vector3 = new Vector3().setFromEuler(bone.rotation)
-
       const new_transform_state = new BoneTransformState(
         bone.name,
         bone.position.clone(),
-        new_rotation,
+        bone.quaternion.clone(),
         bone.scale.clone()
       )
       bone_transforms.push(new_transform_state)
@@ -238,9 +236,7 @@ export class Utility {
 
       if (bone !== null) {
         bone.position.copy(bone_transform.position)
-        const euler: Euler = new Euler()
-        euler.setFromVector3(bone_transform.rotation)
-        bone.rotation.copy(euler)
+        bone.quaternion.copy(bone_transform.rotation)
         bone.scale.copy(bone_transform.scale)
       }
     })

--- a/src/lib/interfaces/BoneTransformState.ts
+++ b/src/lib/interfaces/BoneTransformState.ts
@@ -1,12 +1,12 @@
-import { type Vector3 } from 'three'
+import { type Quaternion, type Vector3 } from 'three'
 
 export default class BoneTransformState {
   public name: string
   public position: Vector3
-  public rotation: Vector3 // Not sure if this is right
+  public rotation: Quaternion
   public scale: Vector3
 
-  constructor (name = '', position: Vector3, rotation: Vector3, scale: Vector3) {
+  constructor (name = '', position: Vector3, rotation: Quaternion, scale: Vector3) {
     this.name = name
     this.position = position
     this.rotation = rotation

--- a/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
+++ b/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
@@ -450,6 +450,7 @@ export class StepEditSkeleton extends EventTarget {
     if (this.ui.dom_move_to_origin_button !== null) {
       this.ui.dom_move_to_origin_button.addEventListener('click', () => {
         // the base bone itself is not at the origin, but the parent is the armature object
+        this.store_bone_state_for_undo()
         this.threejs_skeleton.bones[0].position.set(0, 0, 0)
         this.threejs_skeleton.bones[0].updateWorldMatrix(true, true) // update on renderer
       })

--- a/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
+++ b/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
@@ -63,6 +63,7 @@ export class StepEditSkeleton extends EventTarget {
   private readonly joint_texture = new TextureLoader().load('/images/skeleton-joint-point.png')
 
   private _added_event_listeners: boolean = false
+  private last_skeleton_signature: string = ''
   private readonly preview_plane_manager: PreviewPlaneManager = PreviewPlaneManager.getInstance()
   private readonly arm_plane_manager: ArmPlaneManager = new ArmPlaneManager()
   public readonly independent_bone_movement: IndependentBoneMovement = new IndependentBoneMovement()
@@ -652,8 +653,13 @@ export class StepEditSkeleton extends EventTarget {
     this.create_threejs_skeleton_object()
     this.independent_bone_movement.set_rest_pose(this.threejs_skeleton)
 
-    // Initialize the undo/redo system with the skeleton
-    this.undo_redo_system.set_skeleton(this.threejs_skeleton)
+    // history snapshots restore bones by name, so they stay valid across a
+    // reload of the same rig; only a different rig invalidates them
+    const skeleton_signature = this.threejs_skeleton.bones.map(b => b.name).sort().join('|')
+    const same_rig = skeleton_signature === this.last_skeleton_signature
+    this.last_skeleton_signature = skeleton_signature
+
+    this.undo_redo_system.set_skeleton(this.threejs_skeleton, same_rig)
   }
 
   private create_threejs_skeleton_object (): Skeleton {

--- a/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
+++ b/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
@@ -655,7 +655,9 @@ export class StepEditSkeleton extends EventTarget {
 
     // history snapshots restore bones by name, so they stay valid across a
     // reload of the same rig; only a different rig invalidates them
-    const skeleton_signature = this.threejs_skeleton.bones.map(b => b.name).sort().join('|')
+    const skeleton_signature = this.threejs_skeleton.bones
+      .map(b => `${b.name}:${b.position.x.toFixed(4)},${b.position.y.toFixed(4)},${b.position.z.toFixed(4)}`)
+      .sort().join('|')
     const same_rig = skeleton_signature === this.last_skeleton_signature
     this.last_skeleton_signature = skeleton_signature
 

--- a/src/lib/processes/edit-skeleton/UndoRedoSystem.ts
+++ b/src/lib/processes/edit-skeleton/UndoRedoSystem.ts
@@ -21,9 +21,11 @@ export class UndoRedoSystem extends EventTarget {
   /**
    * Set the skeleton reference that this undo/redo system will operate on
    */
-  public set_skeleton (skeleton: Skeleton): void {
+  public set_skeleton (skeleton: Skeleton, keep_history: boolean = false): void {
     this.skeleton_ref = skeleton
-    this.clear_history()
+    if (!keep_history) {
+      this.clear_history()
+    }
   }
 
   /**

--- a/src/lib/processes/load-model/StepLoadModel.ts
+++ b/src/lib/processes/load-model/StepLoadModel.ts
@@ -6,7 +6,7 @@ import { DOMUtilities } from '../../DOMUtilities.ts'
 
 import { Scene } from 'three/src/scenes/Scene.js'
 import { Mesh } from 'three/src/objects/Mesh.js'
-import { BufferGeometry, Group, type Material, type Object3D } from 'three'
+import { Box3, BufferGeometry, Group, type Material, type Object3D } from 'three'
 import { ModalDialog } from '../../ModalDialog.ts'
 import { Utility } from '../../Utilities.ts'
 import { ModelCleanupUtility } from './ModelCleanupUtility.ts'
@@ -29,6 +29,10 @@ export class StepLoadModel extends EventTarget {
 
   // file the user picked, only used for labeling the analysis report
   private source_file_name: string = 'Unknown file'
+
+
+  private transform_undo_stack: Array<{ kind: 'rotate', axis: 'x' | 'y' | 'z', degrees: number } | { kind: 'translate', dx: number, dy: number, dz: number }> = []
+  private transform_redo_stack: typeof this.transform_undo_stack = []
 
   // diagnostic snapshot of what the file contained vs. what import produced
   private import_analysis: ModelImportAnalysis | null = null
@@ -174,7 +178,70 @@ export class StepLoadModel extends EventTarget {
     this.import_analysis = null
   }
 
+  public rotate_model (axis: 'x' | 'y' | 'z'): void {
+    ModelCleanupUtility.rotate_model_geometry(this.model_meshes(), axis, 90)
+    this.transform_undo_stack.push({ kind: 'rotate', axis, degrees: 90 })
+    this.transform_redo_stack = []
+  }
+
+  public auto_align_model_to_floor (): void {
+    const mesh_data = this.model_meshes()
+    const before_y = this.lowest_model_point(mesh_data)
+
+    ModelCleanupUtility.move_model_to_floor(mesh_data)
+
+    const py = mesh_data.position.y
+    if (py !== 0) {
+      ModelCleanupUtility.translate_model_vertices(mesh_data, 0, py, 0)
+      mesh_data.position.setY(0)
+    }
+
+    const dy = this.lowest_model_point(mesh_data) - before_y
+    if (dy !== 0 && isFinite(dy)) {
+      this.transform_undo_stack.push({ kind: 'translate', dx: 0, dy, dz: 0 })
+      this.transform_redo_stack = []
+    }
+  }
+
+  public undo_model_transform (): boolean {
+    const op = this.transform_undo_stack.pop()
+    if (op === undefined) { return false }
+    this.apply_transform_op(op, true)
+    this.transform_redo_stack.push(op)
+    return true
+  }
+
+  public redo_model_transform (): boolean {
+    const op = this.transform_redo_stack.pop()
+    if (op === undefined) { return false }
+    this.apply_transform_op(op, false)
+    this.transform_undo_stack.push(op)
+    return true
+  }
+
+  private apply_transform_op (op: (typeof this.transform_undo_stack)[number], inverse: boolean): void {
+    const sign = inverse ? -1 : 1
+    if (op.kind === 'rotate') {
+      ModelCleanupUtility.rotate_model_geometry(this.model_meshes(), op.axis, sign * op.degrees)
+    } else {
+      ModelCleanupUtility.translate_model_vertices(this.model_meshes(), sign * op.dx, sign * op.dy, sign * op.dz)
+    }
+  }
+
+  private lowest_model_point (mesh_data: Scene | Group): number {
+    let lowest = Infinity
+    mesh_data.traverse((obj: Object3D) => {
+      if (obj.type === 'Mesh') {
+        const bounding_box = new Box3().setFromObject(obj)
+        lowest = Math.min(lowest, bounding_box.min.y)
+      }
+    })
+    return lowest
+  }
+
   public reset_model_position (): void {
+    this.transform_undo_stack = []
+    this.transform_redo_stack = []
     let i = 0
     this.final_mesh_data.traverse((obj: Object3D) => {
       if (obj.type === 'Mesh') {


### PR DESCRIPTION
Move to origin is now undoable, undo restores rotations with the right rotation order, history survives step changes when the rig is unchanged, and model rotate/align at the position step gets ctrl+z.