### PR TITLE
session persistence

### DIFF
--- a/src/CustomModelUploadBootstrap.ts
+++ b/src/CustomModelUploadBootstrap.ts
@@ -1,10 +1,16 @@
 import { Mesh2MotionEngine } from './Mesh2MotionEngine'
+import { SessionPersistence } from './lib/persistence/SessionPersistence'
 
 export class CustomModelUploadBootstrap {
   private readonly mesh2motion_engine: Mesh2MotionEngine
+  private readonly session_persistence: SessionPersistence
 
   constructor () {
     this.mesh2motion_engine = new Mesh2MotionEngine()
+    this.session_persistence = new SessionPersistence(this.mesh2motion_engine)
+    this.mesh2motion_engine.session_persistence = this.session_persistence
+    this.session_persistence.initialize()
+    void this.session_persistence.try_restore()
   }
 }
 

--- a/src/Mesh2MotionEngine.ts
+++ b/src/Mesh2MotionEngine.ts
@@ -40,6 +40,7 @@ import { CameraShake } from './lib/CameraShake.ts'
 import { DOMUtilities } from './lib/DOMUtilities.ts'
 import { PlatformManager } from './lib/PlatformManager.ts'
 import { NetworkStatusManager } from './lib/NetworkStatusManager.ts'
+import type { SessionPersistence } from './lib/persistence/SessionPersistence.ts'
 
 export class Mesh2MotionEngine {
   public readonly camera = Generators.create_camera()
@@ -68,6 +69,7 @@ export class Mesh2MotionEngine {
 
   // for looking at specific bones
   public process_step: ProcessStep = ProcessStep.LoadModel
+  public session_persistence: SessionPersistence | null = null
   public skeleton_helper: CustomSkeletonHelper | undefined = undefined
   public debugging_visual_object: Group = new Group()
 
@@ -460,6 +462,8 @@ export class Mesh2MotionEngine {
         this.skeleton_helper.hide() // hide skeleton helper in animations listing step
       }
     }
+
+    this.session_persistence?.handle_step_completed()
 
     return this.process_step
   } // end process_step_changed()

--- a/src/lib/SceneEnvironmentManager.ts
+++ b/src/lib/SceneEnvironmentManager.ts
@@ -51,8 +51,8 @@ export class SceneEnvironmentManager {
     // center orbit controls around mid-section area with target change
     this.controls = new OrbitControls(this.camera, this.renderer.domElement)
     this.controls.target.set(0, 0.9, 0)
-    this.controls.autoRotate = false
-    this.controls.autoRotateSpeed = this.turntable_speed
+    this.controls.autoRotate = this.turntable_speed > 0
+    this.controls.autoRotateSpeed = -this.turntable_speed
 
     // Set zoom limits to prevent excessive zooming in or out
     this.controls.minDistance = 0.5 // Minimum zoom (closest to model)

--- a/src/lib/SettingsDropdownManager.ts
+++ b/src/lib/SettingsDropdownManager.ts
@@ -3,6 +3,8 @@ import { DOMUtilities } from './DOMUtilities'
 import { type SceneEnvironmentManager } from './SceneEnvironmentManager'
 
 export class SettingsDropdownManager {
+  private static readonly storage_key = 'mesh2motion-scene-settings'
+
   private readonly ui: UI = UI.getInstance()
   private initialized: boolean = false
   private is_open: boolean = false
@@ -59,6 +61,51 @@ export class SettingsDropdownManager {
     this.initialize_turntable_speed_setting()
     this.initialize_floor_grid_setting()
     this.initialize_background_setting()
+    this.load_saved_settings()
+  }
+
+  private load_saved_settings (): void {
+    try {
+      const raw = localStorage.getItem(SettingsDropdownManager.storage_key)
+      if (raw === null) { return }
+      const saved = JSON.parse(raw)
+
+      if (typeof saved.light_intensity === 'number') {
+        this.scene_environment?.set_light_intensity_multiplier(saved.light_intensity)
+        if (this.ui.dom_light_intensity_input !== null) {
+          this.ui.dom_light_intensity_input.value = saved.light_intensity.toFixed(2)
+        }
+      }
+      if (typeof saved.turntable_speed === 'number') {
+        this.scene_environment?.set_turntable_speed(saved.turntable_speed)
+        if (this.ui.dom_turntable_speed_input !== null) {
+          this.ui.dom_turntable_speed_input.value = saved.turntable_speed.toFixed(1)
+        }
+      }
+      if (typeof saved.floor_grid === 'boolean') {
+        this.scene_environment?.set_floor_grid_visible(saved.floor_grid)
+        if (this.ui.dom_floor_grid_toggle !== null) {
+          this.ui.dom_floor_grid_toggle.checked = saved.floor_grid
+        }
+      }
+      if (typeof saved.solid_background === 'boolean') {
+        if (this.ui.dom_solid_background_toggle !== null) {
+          this.ui.dom_solid_background_toggle.checked = saved.solid_background
+        }
+        this.apply_solid_background(saved.solid_background)
+      }
+    } catch (error) {
+      console.warn('Could not load saved scene settings', error)
+    }
+  }
+
+  private save_settings (): void {
+    localStorage.setItem(SettingsDropdownManager.storage_key, JSON.stringify({
+      light_intensity: this.scene_environment?.get_light_intensity_multiplier() ?? 1.0,
+      turntable_speed: this.scene_environment?.get_turntable_speed() ?? 0,
+      floor_grid: this.ui.dom_floor_grid_toggle?.checked ?? true,
+      solid_background: this.ui.dom_solid_background_toggle?.checked ?? false
+    }))
   }
 
   private initialize_floor_grid_setting (): void {
@@ -73,6 +120,7 @@ export class SettingsDropdownManager {
 
     floor_grid_toggle.addEventListener('change', () => {
       this.scene_environment?.set_floor_grid_visible(floor_grid_toggle.checked)
+      this.save_settings()
     })
   }
 
@@ -88,6 +136,7 @@ export class SettingsDropdownManager {
 
     solid_background_toggle.addEventListener('change', () => {
       this.apply_solid_background(solid_background_toggle.checked)
+      this.save_settings()
     })
   }
 
@@ -114,6 +163,7 @@ export class SettingsDropdownManager {
       }
 
       this.scene_environment?.set_light_intensity_multiplier(slider_value)
+      this.save_settings()
     })
   }
 
@@ -136,6 +186,7 @@ export class SettingsDropdownManager {
       }
 
       this.scene_environment?.set_turntable_speed(slider_value)
+      this.save_settings()
     })
   }
 

--- a/src/lib/Utilities.ts
+++ b/src/lib/Utilities.ts
@@ -1,5 +1,5 @@
 import {
-  Vector3, Vector2, type Object3D, Mesh, Group, Bone, type Skeleton, Euler, Raycaster,
+  Vector3, Vector2, type Object3D, Mesh, Group, Bone, type Skeleton, Raycaster,
   type PerspectiveCamera, type Scene, type Object3DEventMap, type BufferAttribute, type BufferGeometry, type InterleavedBufferAttribute
 } from 'three'
 import BoneTransformState from './interfaces/BoneTransformState'
@@ -213,12 +213,10 @@ export class Utility {
   static store_bone_transforms (skeleton: Skeleton): BoneTransformState[] {
     const bone_transforms: BoneTransformState[] = []
     skeleton.bones.forEach((bone: Bone) => {
-      const new_rotation: Vector3 = new Vector3().setFromEuler(bone.rotation)
-
       const new_transform_state = new BoneTransformState(
         bone.name,
         bone.position.clone(),
-        new_rotation,
+        bone.quaternion.clone(),
         bone.scale.clone()
       )
       bone_transforms.push(new_transform_state)
@@ -238,9 +236,7 @@ export class Utility {
 
       if (bone !== null) {
         bone.position.copy(bone_transform.position)
-        const euler: Euler = new Euler()
-        euler.setFromVector3(bone_transform.rotation)
-        bone.rotation.copy(euler)
+        bone.quaternion.copy(bone_transform.rotation)
         bone.scale.copy(bone_transform.scale)
       }
     })

--- a/src/lib/interfaces/BoneTransformState.ts
+++ b/src/lib/interfaces/BoneTransformState.ts
@@ -1,12 +1,12 @@
-import { type Vector3 } from 'three'
+import { type Quaternion, type Vector3 } from 'three'
 
 export default class BoneTransformState {
   public name: string
   public position: Vector3
-  public rotation: Vector3 // Not sure if this is right
+  public rotation: Quaternion
   public scale: Vector3
 
-  constructor (name = '', position: Vector3, rotation: Vector3, scale: Vector3) {
+  constructor (name = '', position: Vector3, rotation: Quaternion, scale: Vector3) {
     this.name = name
     this.position = position
     this.rotation = rotation

--- a/src/lib/persistence/SessionPersistence.ts
+++ b/src/lib/persistence/SessionPersistence.ts
@@ -1,0 +1,334 @@
+import { Quaternion, Vector3 } from 'three'
+import { ProcessStep } from '../enums/ProcessStep'
+import { SkeletonType } from '../enums/SkeletonType'
+import { RigConfig } from '../RigConfig'
+import BoneTransformState from '../interfaces/BoneTransformState'
+import type { Mesh2MotionEngine } from '../../Mesh2MotionEngine'
+import type { AnimationMirrorExportMode } from '../processes/animations-listing/interfaces/AnimationExportSelection'
+
+interface SavedAnimationSelection {
+  name: string
+  mirror_export_mode: AnimationMirrorExportMode
+}
+
+interface SavedSession {
+  step: string
+  skeleton_type: string
+  hand_skeleton_type: string
+  skeleton_scale: number
+  bone_transforms: Array<{ name: string, position: number[], rotation: number[], scale: number[] }>
+  edit_settings: {
+    mirror_mode?: boolean
+    use_head_weight_correction?: boolean
+    head_plane_height?: number
+    use_arm_plane_correction?: boolean
+    arm_plane_offset?: number
+  }
+  animation_selections: SavedAnimationSelection[]
+  saved_at: number
+}
+
+/**
+ * Saves enough of the working session (localStorage for state, IndexedDB for
+ * the model file) that closing the app and coming back resumes where the user
+ * left off. Only active on the create page; the marketing page drives its own
+ * flow and never attaches this.
+ */
+export class SessionPersistence {
+  private static readonly state_key = 'mesh2motion-session'
+  private static readonly db_name = 'mesh2motion-session'
+  private static readonly db_store = 'files'
+
+  private readonly engine: Mesh2MotionEngine
+  private is_restoring: boolean = false
+  private save_debounce_timer: ReturnType<typeof setTimeout> | null = null
+
+  constructor (engine: Mesh2MotionEngine) {
+    this.engine = engine
+  }
+
+  public initialize (): void {
+    this.engine.load_model_step.addEventListener('modelLoaded', () => {
+      if (this.is_restoring) { return }
+      void this.store_model_source()
+      this.save_state()
+    })
+
+    this.engine.edit_skeleton_step.addEventListener('skeletonTransformed', () => {
+      if (this.is_restoring) { return }
+      this.debounced_save()
+    })
+
+    window.addEventListener('beforeunload', () => { this.save_state() })
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') { this.save_state() }
+    })
+  }
+
+  public handle_step_completed (): void {
+    this.save_state()
+  }
+
+  private debounced_save (): void {
+    if (this.save_debounce_timer !== null) {
+      clearTimeout(this.save_debounce_timer)
+    }
+    this.save_debounce_timer = setTimeout(() => {
+      this.save_debounce_timer = null
+      this.save_state()
+    }, 500)
+  }
+
+  public save_state (): void {
+    if (this.is_restoring) { return }
+
+    if (this.engine.process_step === ProcessStep.LoadModel) {
+      this.clear_session()
+      return
+    }
+
+    try {
+      const session: SavedSession = {
+        step: this.engine.process_step,
+        skeleton_type: this.engine.load_skeleton_step.skeleton_type(),
+        hand_skeleton_type: this.engine.ui.dom_hand_skeleton_selection?.value ?? '',
+        skeleton_scale: this.engine.load_skeleton_step.skeleton_scale(),
+        bone_transforms: this.serialize_bone_transforms(),
+        edit_settings: {
+          mirror_mode: this.engine.edit_skeleton_step.is_mirror_mode_enabled(),
+          use_head_weight_correction: this.engine.edit_skeleton_step.use_head_weight_correction(),
+          head_plane_height: this.engine.edit_skeleton_step.get_preview_plane_height(),
+          use_arm_plane_correction: this.engine.edit_skeleton_step.use_arm_plane_correction(),
+          arm_plane_offset: this.engine.edit_skeleton_step.get_arm_plane_offset()
+        },
+        animation_selections: this.serialize_animation_selections(),
+        saved_at: Date.now()
+      }
+      localStorage.setItem(SessionPersistence.state_key, JSON.stringify(session))
+    } catch (error) {
+      console.warn('Could not save session state', error)
+    }
+  }
+
+  public clear_session (): void {
+    localStorage.removeItem(SessionPersistence.state_key)
+    void this.delete_model_source()
+  }
+
+  public async try_restore (): Promise<void> {
+    let session: SavedSession | null = null
+    try {
+      const raw = localStorage.getItem(SessionPersistence.state_key)
+      if (raw === null) { return }
+      session = JSON.parse(raw) as SavedSession
+    } catch (error) {
+      console.warn('Saved session is unreadable, starting fresh', error)
+      this.clear_session()
+      return
+    }
+
+    if (session === null || session.step === ProcessStep.LoadModel) { return }
+
+    const model = await this.read_model_source()
+    if (model === null || model.data === null || model.data === undefined) { return }
+
+    this.is_restoring = true
+    try {
+      this.engine.load_model_step.set_source_file_name(model.file_name)
+
+      const on_model_loaded = (): void => {
+        this.engine.load_model_step.removeEventListener('modelLoaded', on_model_loaded)
+        this.restore_after_model_loaded(session as SavedSession)
+      }
+      this.engine.load_model_step.addEventListener('modelLoaded', on_model_loaded)
+      this.engine.load_model_step.load_model_file(model.data, model.extension)
+    } catch (error) {
+      console.warn('Session restore failed', error)
+      this.is_restoring = false
+    }
+  }
+
+  private restore_after_model_loaded (session: SavedSession): void {
+    const skeleton_type = session.skeleton_type as SkeletonType
+    const rig_file = RigConfig.rig_file_for(skeleton_type)
+
+    if (skeleton_type === SkeletonType.None || rig_file === undefined) {
+      this.is_restoring = false
+      return
+    }
+
+    this.engine.load_skeleton_step.restore_skeleton_selection(
+      skeleton_type,
+      session.hand_skeleton_type ?? '',
+      session.skeleton_scale > 0 ? session.skeleton_scale : 1.0
+    )
+
+    const on_skeleton_loaded = (): void => {
+      this.engine.load_skeleton_step.removeEventListener('skeletonLoaded', on_skeleton_loaded)
+      this.restore_after_skeleton_loaded(session)
+    }
+    this.engine.load_skeleton_step.addEventListener('skeletonLoaded', on_skeleton_loaded)
+    this.engine.load_skeleton_step.load_skeleton_file(rig_file)
+  }
+
+  private restore_after_skeleton_loaded (session: SavedSession): void {
+    try {
+      this.restore_edit_settings(session)
+
+      if (Array.isArray(session.bone_transforms) && session.bone_transforms.length > 0) {
+        this.engine.edit_skeleton_step.restore_bone_snapshot(this.deserialize_bone_transforms(session.bone_transforms))
+      }
+
+      const wants_animations_step = session.step === ProcessStep.AnimationsListing ||
+        session.step === ProcessStep.BindPose
+      if (wants_animations_step) {
+        this.engine.setup_weight_skinning_config()
+        this.engine.process_step_changed(ProcessStep.BindPose)
+        this.restore_animation_selections(session.animation_selections ?? [])
+        return
+      }
+    } catch (error) {
+      console.warn('Session restore failed partway', error)
+    }
+
+    this.finish_restore()
+  }
+
+  private restore_animation_selections (selections: SavedAnimationSelection[]): void {
+    if (selections.length === 0) {
+      this.finish_restore()
+      return
+    }
+
+    let attempts = 0
+    const timer = setInterval(() => {
+      const search = this.engine.animations_listing_step.animation_search
+      const clips_ready = this.engine.animations_listing_step.animation_clips().length > 0
+      if (search !== null && clips_ready) {
+        clearInterval(timer)
+        search.apply_export_selections_by_name(selections)
+        this.finish_restore()
+      } else if (++attempts > 150) {
+        clearInterval(timer)
+        this.finish_restore()
+      }
+    }, 200)
+  }
+
+  private finish_restore (): void {
+    this.is_restoring = false
+    this.save_state()
+  }
+
+  private restore_edit_settings (session: SavedSession): void {
+    const settings = session.edit_settings ?? {}
+
+    if (typeof settings.mirror_mode === 'boolean') {
+      this.engine.edit_skeleton_step.set_mirror_mode_enabled(settings.mirror_mode)
+      if (this.engine.ui.dom_mirror_skeleton_checkbox !== null) {
+        this.engine.ui.dom_mirror_skeleton_checkbox.checked = settings.mirror_mode
+      }
+    }
+    if (typeof settings.use_head_weight_correction === 'boolean') {
+      this.engine.edit_skeleton_step.set_use_head_weight_correction(settings.use_head_weight_correction)
+    }
+    if (typeof settings.head_plane_height === 'number') {
+      this.engine.edit_skeleton_step.set_preview_plane_height(settings.head_plane_height)
+    }
+    if (typeof settings.use_arm_plane_correction === 'boolean') {
+      this.engine.edit_skeleton_step.set_use_arm_plane_correction(settings.use_arm_plane_correction)
+      if (this.engine.ui.dom_arm_plane_checkbox !== null) {
+        this.engine.ui.dom_arm_plane_checkbox.checked = settings.use_arm_plane_correction
+      }
+    }
+    if (typeof settings.arm_plane_offset === 'number') {
+      this.engine.edit_skeleton_step.set_arm_plane_offset(settings.arm_plane_offset)
+      if (this.engine.ui.dom_arm_plane_offset_input !== null) {
+        this.engine.ui.dom_arm_plane_offset_input.value = String(settings.arm_plane_offset)
+      }
+    }
+  }
+
+  private serialize_bone_transforms (): SavedSession['bone_transforms'] {
+    try {
+      const skeleton = this.engine.edit_skeleton_step.skeleton()
+      if (skeleton?.bones === undefined || skeleton.bones.length === 0) { return [] }
+      return skeleton.bones.map((bone) => ({
+        name: bone.name,
+        position: bone.position.toArray(),
+        rotation: bone.quaternion.toArray() as number[],
+        scale: bone.scale.toArray()
+      }))
+    } catch {
+      return []
+    }
+  }
+
+  private deserialize_bone_transforms (saved: SavedSession['bone_transforms']): BoneTransformState[] {
+    return saved.map((bone) => new BoneTransformState(
+      bone.name,
+      new Vector3().fromArray(bone.position),
+      new Quaternion().fromArray(bone.rotation),
+      new Vector3().fromArray(bone.scale)
+    ))
+  }
+
+  private serialize_animation_selections (): SavedAnimationSelection[] {
+    const search = this.engine.animations_listing_step.animation_search
+    if (search === null) { return [] }
+    return search.get_selected_animations().map((animation) => ({
+      name: animation.name,
+      mirror_export_mode: animation.mirror_export_mode ?? 'none'
+    }))
+  }
+
+  private async open_db (): Promise<IDBDatabase> {
+    return await new Promise((resolve, reject) => {
+      const request = indexedDB.open(SessionPersistence.db_name, 1)
+      request.onupgradeneeded = () => {
+        if (!request.result.objectStoreNames.contains(SessionPersistence.db_store)) {
+          request.result.createObjectStore(SessionPersistence.db_store)
+        }
+      }
+      request.onsuccess = () => { resolve(request.result) }
+      request.onerror = () => { reject(request.error) }
+    })
+  }
+
+  private async store_model_source (): Promise<void> {
+    try {
+      const source = this.engine.load_model_step.model_source_data()
+      if (source.data === null) { return }
+      const db = await this.open_db()
+      const transaction = db.transaction(SessionPersistence.db_store, 'readwrite')
+      transaction.objectStore(SessionPersistence.db_store).put(source, 'model')
+      db.close()
+    } catch (error) {
+      console.warn('Could not store model for session restore', error)
+    }
+  }
+
+  private async read_model_source (): Promise<{ data: string | ArrayBuffer | null, extension: string, file_name: string } | null> {
+    try {
+      const db = await this.open_db()
+      return await new Promise((resolve) => {
+        const request = db.transaction(SessionPersistence.db_store, 'readonly')
+          .objectStore(SessionPersistence.db_store).get('model')
+        request.onsuccess = () => { db.close(); resolve(request.result ?? null) }
+        request.onerror = () => { db.close(); resolve(null) }
+      })
+    } catch {
+      return null
+    }
+  }
+
+  private async delete_model_source (): Promise<void> {
+    try {
+      const db = await this.open_db()
+      db.transaction(SessionPersistence.db_store, 'readwrite')
+        .objectStore(SessionPersistence.db_store).delete('model')
+      db.close()
+    } catch {
+    }
+  }
+}

--- a/src/lib/processes/animations-listing/AnimationSearch.ts
+++ b/src/lib/processes/animations-listing/AnimationSearch.ts
@@ -474,6 +474,29 @@ export class AnimationSearch extends EventTarget {
     this.dispatchEvent(this.custom_event)
   }
 
+  // used by session restore: re-check previously selected animations by name
+  public apply_export_selections_by_name (selections: Array<{ name: string, mirror_export_mode: AnimationMirrorExportMode }>): void {
+    const selection_by_name = new Map(selections.map(selection => [selection.name, selection]))
+
+    this.all_animations.forEach((animation) => {
+      const saved = selection_by_name.get(animation.name)
+      if (saved !== undefined) {
+        animation.isChecked = true
+        animation.mirror_export_mode = saved.mirror_export_mode ?? 'none'
+      }
+    })
+
+    this.render_filtered_animations(this.filter_input?.value.toLowerCase() ?? '')
+
+    this.custom_event = new CustomEvent('export-options-changed', {
+      detail: {
+        selectedAnimations: this.get_selected_animation_indices(),
+        exportAnimationCount: this.get_selected_export_animation_count()
+      }
+    })
+    this.dispatchEvent(this.custom_event)
+  }
+
   private update_all_checkboxes_in_ui (checked_state: boolean): void {
     if (this.animation_list_container === null) {
       return

--- a/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
+++ b/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
@@ -2,6 +2,7 @@ import { UI } from '../../UI.ts'
 import { Generators } from '../../Generators.ts'
 import { Utility } from '../../Utilities.ts'
 import { UndoRedoSystem } from './UndoRedoSystem.ts'
+import type BoneTransformState from '../../interfaces/BoneTransformState.ts'
 import { PreviewPlaneManager } from './PreviewPlaneManager.ts'
 import { ArmPlaneManager } from './ArmPlaneManager.ts'
 import { ArmWeightCorrector } from '../../solvers/ArmWeightCorrector.ts'
@@ -568,6 +569,13 @@ export class StepEditSkeleton extends EventTarget {
   }
 
   // returning back to edit skeleton step later will call this to reset undo state
+  // used by session restore to put saved bone edits back onto a freshly
+  // loaded skeleton
+  public restore_bone_snapshot (snapshot: BoneTransformState[]): void {
+    Utility.restore_bone_transforms(this.threejs_skeleton, snapshot)
+    this.dispatchEvent(new CustomEvent('skeletonTransformed'))
+  }
+
   public clear_undo_history (): void {
     this.undo_redo_system.clear_history()
   }

--- a/src/lib/processes/export-to-file/DownloadSettings.ts
+++ b/src/lib/processes/export-to-file/DownloadSettings.ts
@@ -24,6 +24,8 @@ export enum FbxExportPreset {
 }
 
 export class DownloadSettings extends EventTarget {
+  private static readonly storage_key = 'mesh2motion-export-settings'
+
   private selected_bone_naming_structure: BoneNamingStructure = this.get_default_bone_naming_structure()
   private selected_export_contents: ExportContents = this.get_default_export_contents()
   private selected_export_format: ExportFormat = this.get_default_export_format()
@@ -41,8 +43,40 @@ export class DownloadSettings extends EventTarget {
   constructor () {
     super()
     this.initialize_dom_elements()
+    this.load_saved_settings()
     this.update_fbx_preset_ui_visibility()
     this.add_event_listeners()
+  }
+
+  private load_saved_settings (): void {
+    try {
+      const raw = localStorage.getItem(DownloadSettings.storage_key)
+      if (raw === null) { return }
+      const saved = JSON.parse(raw)
+      if (this.is_bone_naming_structure(saved.bone_naming_structure)) {
+        this.selected_bone_naming_structure = saved.bone_naming_structure
+      }
+      if (this.is_export_contents(saved.export_contents)) {
+        this.selected_export_contents = saved.export_contents
+      }
+      if (this.is_export_format(saved.export_format)) {
+        this.selected_export_format = saved.export_format
+      }
+      if (this.is_fbx_export_preset(saved.fbx_export_preset)) {
+        this.selected_fbx_export_preset = saved.fbx_export_preset
+      }
+    } catch (error) {
+      console.warn('Could not load saved export settings', error)
+    }
+  }
+
+  private save_settings (): void {
+    localStorage.setItem(DownloadSettings.storage_key, JSON.stringify({
+      bone_naming_structure: this.selected_bone_naming_structure,
+      export_contents: this.selected_export_contents,
+      export_format: this.selected_export_format,
+      fbx_export_preset: this.selected_fbx_export_preset
+    }))
   }
 
   public bone_naming_structure (): BoneNamingStructure {
@@ -65,17 +99,11 @@ export class DownloadSettings extends EventTarget {
   // options only apply to the human skeleton, so that section is shown/hidden here while
   // the export contents options remain available regardless of skeleton type.
   public update_download_settings_ui_visibility (skeleton_type: SkeletonType): void {
-    // reset to defaults
-    this.selected_bone_naming_structure = this.get_default_bone_naming_structure()
+    // re-apply the user's saved settings (or the defaults) to the radio groups
+    this.load_saved_settings()
     this.set_radio_group_value(this.dom_bone_naming_group, 'bone-naming-structure', this.selected_bone_naming_structure)
-
-    this.selected_export_contents = this.get_default_export_contents()
     this.set_radio_group_value(this.dom_export_contents_group, 'export-contents', this.selected_export_contents)
-
-    this.selected_export_format = this.get_default_export_format()
     this.set_radio_group_value(this.dom_export_format_group, 'export-format', this.selected_export_format)
-
-    this.selected_fbx_export_preset = this.get_default_fbx_export_preset()
     this.set_radio_group_value(this.dom_fbx_preset_group, 'fbx-export-preset', this.selected_fbx_export_preset)
 
     const is_human_skeleton = skeleton_type === SkeletonType.Human
@@ -139,6 +167,8 @@ export class DownloadSettings extends EventTarget {
         this.selected_bone_naming_structure = this.get_default_bone_naming_structure()
       }
 
+      this.save_settings()
+
       this.dispatchEvent(new CustomEvent('bone-naming-structure-changed', {
         detail: { boneNamingStructure: this.selected_bone_naming_structure }
       }))
@@ -157,6 +187,8 @@ export class DownloadSettings extends EventTarget {
         this.selected_export_contents = this.get_default_export_contents()
       }
 
+      this.save_settings()
+
       this.dispatchEvent(new CustomEvent('export-contents-changed', {
         detail: { exportContents: this.selected_export_contents }
       }))
@@ -174,6 +206,8 @@ export class DownloadSettings extends EventTarget {
       } else {
         this.selected_export_format = this.get_default_export_format()
       }
+
+      this.save_settings()
 
       this.dispatchEvent(new CustomEvent('export-format-changed', {
         detail: { exportFormat: this.selected_export_format }
@@ -194,6 +228,8 @@ export class DownloadSettings extends EventTarget {
       } else {
         this.selected_fbx_export_preset = this.get_default_fbx_export_preset()
       }
+
+      this.save_settings()
 
       this.dispatchEvent(new CustomEvent('fbx-export-preset-changed', {
         detail: { fbxExportPreset: this.selected_fbx_export_preset }

--- a/src/lib/processes/load-model/StepLoadModel.ts
+++ b/src/lib/processes/load-model/StepLoadModel.ts
@@ -30,6 +30,10 @@ export class StepLoadModel extends EventTarget {
   // file the user picked, only used for labeling the analysis report
   private source_file_name: string = 'Unknown file'
 
+  // kept so a session restore can re-feed the exact same input to load_model_file
+  private source_file_data: string | ArrayBuffer | null = null
+  private source_file_extension: string = ''
+
   // diagnostic snapshot of what the file contained vs. what import produced
   private import_analysis: ModelImportAnalysis | null = null
 
@@ -160,6 +164,18 @@ export class StepLoadModel extends EventTarget {
     }
   }
 
+  public model_source_data (): { data: string | ArrayBuffer | null, extension: string, file_name: string } {
+    return {
+      data: this.source_file_data,
+      extension: this.source_file_extension,
+      file_name: this.source_file_name
+    }
+  }
+
+  public set_source_file_name (name: string): void {
+    this.source_file_name = name
+  }
+
   public clear_loaded_model_data (): void {
     this.original_model_data = new Scene()
     this.final_mesh_data = new Scene()
@@ -201,6 +217,9 @@ export class StepLoadModel extends EventTarget {
   }
 
   public load_model_file (model_file_path: string | ArrayBuffer | null, file_extension: string): void {
+    this.source_file_data = model_file_path
+    this.source_file_extension = file_extension
+
     // only the FBX loader can flag this, so clear it here or a previous broken FBX
     // would keep forcing the fallback material onto every model loaded after it
     this.mesh_has_broken_material = false

--- a/src/lib/processes/load-skeleton/StepLoadSkeleton.ts
+++ b/src/lib/processes/load-skeleton/StepLoadSkeleton.ts
@@ -256,6 +256,36 @@ export class StepLoadSkeleton extends EventTarget {
     })
   }
 
+  // used by session restore to put the UI and internal state back the way the
+  // user had it before loading the skeleton file
+  public restore_skeleton_selection (skeleton_type: SkeletonType, hand_type: string, scale: number): void {
+    if (this.ui.dom_skeleton_drop_type !== null) {
+      if (this.has_select_skeleton_ui_option()) {
+        this.ui.dom_skeleton_drop_type.options.remove(0)
+      }
+      this.ui.dom_skeleton_drop_type.value = skeleton_type
+    }
+
+    if (this.ui.dom_hand_skeleton_selection !== null && hand_type !== '') {
+      this.ui.dom_hand_skeleton_selection.value = hand_type
+    }
+
+    this.manual_set_skeleton_type = skeleton_type
+    this.skeleton_scale_percentage = scale
+
+    if (this.ui.dom_scale_skeleton_input !== null) {
+      this.ui.dom_scale_skeleton_input.value = String(scale)
+    }
+    if (this.ui.dom_scale_skeleton_percentage_display !== null) {
+      this.ui.dom_scale_skeleton_percentage_display.textContent = Math.round(scale * 100).toString() + '%'
+    }
+    if (this.ui.dom_scale_skeleton_controls !== null) {
+      this.ui.dom_scale_skeleton_controls.style.display = 'flex'
+    }
+
+    this.toggle_ui_hand_skeleton_options()
+  }
+
   private has_select_skeleton_ui_option (): boolean {
     return this.ui.dom_skeleton_drop_type?.options[0].value === 'select-skeleton'
   }

--- a/src/retarget/RetargetSessionPersistence.ts
+++ b/src/retarget/RetargetSessionPersistence.ts
@@ -1,0 +1,164 @@
+import { AnimationRetargetService } from './AnimationRetargetService'
+import type { Mesh2MotionEngine } from '../Mesh2MotionEngine'
+import type { StepLoadSourceSkeleton } from './steps/StepLoadSourceSkeleton'
+import type { StepLoadTargetModel } from './steps/StepLoadTargetModel'
+import type { StepBoneMapping } from './steps/StepBoneMapping'
+
+interface SavedRetargetSession {
+  skeleton_selection: string
+  bone_mappings: Record<string, string>
+  saved_at: number
+}
+
+/**
+ * Same idea as SessionPersistence on the create page, scoped to the retarget
+ * page: source skeleton choice and bone mappings in localStorage, the
+ * uploaded target model in IndexedDB.
+ */
+export class RetargetSessionPersistence {
+  private static readonly state_key = 'mesh2motion-retarget-session'
+  private static readonly db_name = 'mesh2motion-retarget-session'
+  private static readonly db_store = 'files'
+
+  private readonly engine: Mesh2MotionEngine
+  private readonly source_skeleton_step: StepLoadSourceSkeleton
+  private readonly target_model_step: StepLoadTargetModel
+  private readonly bone_mapping_step: StepBoneMapping
+  private is_restoring: boolean = false
+  private pending_mappings: Record<string, string> | null = null
+
+  constructor (
+    engine: Mesh2MotionEngine,
+    source_skeleton_step: StepLoadSourceSkeleton,
+    target_model_step: StepLoadTargetModel,
+    bone_mapping_step: StepBoneMapping
+  ) {
+    this.engine = engine
+    this.source_skeleton_step = source_skeleton_step
+    this.target_model_step = target_model_step
+    this.bone_mapping_step = bone_mapping_step
+  }
+
+  public initialize (): void {
+    this.target_model_step.addEventListener('target-model-loaded', () => {
+      if (this.is_restoring) {
+        this.apply_pending_mappings()
+        return
+      }
+      void this.store_model_source()
+      this.save_state()
+    })
+
+    this.source_skeleton_step.addEventListener('skeleton-loaded', () => {
+      if (this.is_restoring) { return }
+      this.save_state()
+    })
+
+    this.bone_mapping_step.addEventListener('bone-mappings-changed', () => {
+      if (this.is_restoring) { return }
+      this.save_state()
+    })
+
+    window.addEventListener('beforeunload', () => { this.save_state() })
+  }
+
+  public save_state (): void {
+    if (this.is_restoring) { return }
+    try {
+      const session: SavedRetargetSession = {
+        skeleton_selection: this.source_skeleton_step.current_skeleton_selection(),
+        bone_mappings: Object.fromEntries(AnimationRetargetService.getInstance().get_bone_mappings()),
+        saved_at: Date.now()
+      }
+      localStorage.setItem(RetargetSessionPersistence.state_key, JSON.stringify(session))
+    } catch (error) {
+      console.warn('Could not save retarget session', error)
+    }
+  }
+
+  public async try_restore (): Promise<void> {
+    let session: SavedRetargetSession | null = null
+    try {
+      const raw = localStorage.getItem(RetargetSessionPersistence.state_key)
+      if (raw === null) { return }
+      session = JSON.parse(raw) as SavedRetargetSession
+    } catch {
+      localStorage.removeItem(RetargetSessionPersistence.state_key)
+      return
+    }
+
+    if (session === null) { return }
+
+    this.is_restoring = true
+    try {
+      if (session.skeleton_selection !== '') {
+        this.source_skeleton_step.restore_skeleton_selection(session.skeleton_selection)
+      }
+
+      const model = await this.read_model_source()
+      if (model !== null && model.data !== null && model.data !== undefined) {
+        this.pending_mappings = session.bone_mappings ?? null
+        this.engine.load_model_step.set_source_file_name(model.file_name)
+        this.target_model_step.load_target_model_from_data(model.data, model.extension)
+      } else {
+        this.is_restoring = false
+      }
+    } catch (error) {
+      console.warn('Retarget session restore failed', error)
+      this.is_restoring = false
+    }
+  }
+
+  private apply_pending_mappings (): void {
+    const mappings = this.pending_mappings
+    this.pending_mappings = null
+
+    if (mappings !== null && Object.keys(mappings).length > 0) {
+      AnimationRetargetService.getInstance().set_bone_mappings(new Map(Object.entries(mappings)))
+      this.bone_mapping_step.update_bone_lists()
+    }
+
+    this.is_restoring = false
+    this.save_state()
+  }
+
+  private async open_db (): Promise<IDBDatabase> {
+    return await new Promise((resolve, reject) => {
+      const request = indexedDB.open(RetargetSessionPersistence.db_name, 1)
+      request.onupgradeneeded = () => {
+        if (!request.result.objectStoreNames.contains(RetargetSessionPersistence.db_store)) {
+          request.result.createObjectStore(RetargetSessionPersistence.db_store)
+        }
+      }
+      request.onsuccess = () => { resolve(request.result) }
+      request.onerror = () => { reject(request.error) }
+    })
+  }
+
+  private async store_model_source (): Promise<void> {
+    try {
+      const source = this.engine.load_model_step.model_source_data()
+      if (source.data === null) { return }
+      const db = await this.open_db()
+      db.transaction(RetargetSessionPersistence.db_store, 'readwrite')
+        .objectStore(RetargetSessionPersistence.db_store).put(source, 'model')
+      db.close()
+    } catch (error) {
+      console.warn('Could not store target model for retarget session', error)
+    }
+  }
+
+  private async read_model_source (): Promise<{ data: string | ArrayBuffer | null, extension: string, file_name: string } | null> {
+    try {
+      const db = await this.open_db()
+      return await new Promise((resolve) => {
+        const request = db.transaction(RetargetSessionPersistence.db_store, 'readonly')
+          .objectStore(RetargetSessionPersistence.db_store).get('model')
+        request.onsuccess = () => { db.close(); resolve(request.result ?? null) }
+        request.onerror = () => { db.close(); resolve(null) }
+      })
+    } catch {
+      return null
+    }
+  }
+}

--- a/src/retarget/RetargetSessionPersistence.ts
+++ b/src/retarget/RetargetSessionPersistence.ts
@@ -116,6 +116,7 @@ export class RetargetSessionPersistence {
     if (mappings !== null && Object.keys(mappings).length > 0) {
       AnimationRetargetService.getInstance().set_bone_mappings(new Map(Object.entries(mappings)))
       this.bone_mapping_step.update_bone_lists()
+      this.bone_mapping_step.dispatchEvent(new CustomEvent('bone-mappings-changed'))
     }
 
     this.is_restoring = false

--- a/src/retarget/retarget.ts
+++ b/src/retarget/retarget.ts
@@ -8,6 +8,7 @@ import { RetargetAnimationListing } from './RetargetAnimationListing.ts'
 import { AnimationRetargetService } from './AnimationRetargetService'
 import { type SkeletonType } from '../lib/enums/SkeletonType.ts'
 import { RetargetUtils } from './RetargetUtils.ts'
+import { RetargetSessionPersistence } from './RetargetSessionPersistence.ts'
 
 class RetargetModule {
   private readonly mesh2motion_engine: Mesh2MotionEngine
@@ -16,6 +17,7 @@ class RetargetModule {
   private readonly step_bone_mapping: StepBoneMapping
   private readonly retarget_animation_preview: RetargetAnimationPreview
   private animation_listing_step: RetargetAnimationListing | null = null
+  private readonly session_persistence: RetargetSessionPersistence
 
   private back_to_bone_map_button: HTMLButtonElement | null = null
   private continue_to_listing_button: HTMLButtonElement | null = null
@@ -43,6 +45,13 @@ class RetargetModule {
 
     // Initialize animation preview
     this.retarget_animation_preview = new RetargetAnimationPreview(this.step_bone_mapping)
+
+    this.session_persistence = new RetargetSessionPersistence(
+      this.mesh2motion_engine,
+      this.step_load_source_skeleton,
+      this.step_load_target_model,
+      this.step_bone_mapping
+    )
   }
 
   public init (): void {
@@ -51,6 +60,8 @@ class RetargetModule {
     this.step_load_target_model.begin()
     this.step_bone_mapping.begin()
     this.retarget_animation_preview.begin()
+    this.session_persistence.initialize()
+    void this.session_persistence.try_restore()
   }
 
   public add_event_listeners (): void {

--- a/src/retarget/steps/StepLoadSourceSkeleton.ts
+++ b/src/retarget/steps/StepLoadSourceSkeleton.ts
@@ -54,6 +54,17 @@ export class StepLoadSourceSkeleton extends EventTarget {
     this.dispatchEvent(new CustomEvent('skeleton-loading'))
   }
 
+  public restore_skeleton_selection (select_value: string): void {
+    if (this.skeleton_type_select === null) { return }
+    if (this.skeleton_type_select.value === select_value) { return }
+    this.skeleton_type_select.value = select_value
+    this.handle_skeleton_selection_change()
+  }
+
+  public current_skeleton_selection (): string {
+    return this.skeleton_type_select?.value ?? ''
+  }
+
   private add_event_listeners (): void {
     // Skeleton selection change listener
     this.skeleton_type_select?.addEventListener('change', () => {

--- a/src/retarget/steps/StepLoadTargetModel.ts
+++ b/src/retarget/steps/StepLoadTargetModel.ts
@@ -97,34 +97,39 @@ export class StepLoadTargetModel extends EventTarget {
         return
       }
 
-      // Configure the model loader to preserve all objects (bones, etc.)
-      this.mesh2motion_engine.load_model_step.set_preserve_skinned_mesh(true)
+      this.mesh2motion_engine.load_model_step.set_source_file_name(file.name)
 
-      // Create a URL for the file and load it
-      const file_url = URL.createObjectURL(file)
-
-      try {
-        this.mesh2motion_engine.load_model_step.load_model_file(file_url, file_extension)
-
-        this.mesh2motion_engine.load_model_step.addEventListener('modelLoadedForRetargeting', () => {
-          console.log('Model loaded for retargeting successfully.')
-          URL.revokeObjectURL(file_url) // Revoke the object URL after loading is complete
-
-          // read in mesh2motion engine's retargetable model data (this is the target)
-          const retargetable_meshes: Scene = this.mesh2motion_engine.load_model_step.get_final_retargetable_model_data()
-          const is_valid_skinned_mesh = RetargetUtils.validate_skinned_mesh_has_bones(retargetable_meshes)
-
-          if (is_valid_skinned_mesh) {
-            this.resolve_model_root_bones(retargetable_meshes).catch((error) => {
-              console.error('Error resolving multiple skeletons in model:', error)
-            })
-          }
-        }, { once: true })
-      } catch (error) {
-        console.error('Error loading model:', error)
-        new ModalDialog('Error loading model file.', 'Error').show()
-        URL.revokeObjectURL(file_url) // Clean up the URL
+      const reader = new FileReader()
+      reader.readAsDataURL(file)
+      reader.onload = () => {
+        this.load_target_model_from_data(reader.result, file_extension)
       }
+    }
+  }
+
+  public load_target_model_from_data (data: string | ArrayBuffer | null, file_extension: string): void {
+    // Configure the model loader to preserve all objects (bones, etc.)
+    this.mesh2motion_engine.load_model_step.set_preserve_skinned_mesh(true)
+
+    try {
+      this.mesh2motion_engine.load_model_step.load_model_file(data, file_extension)
+
+      this.mesh2motion_engine.load_model_step.addEventListener('modelLoadedForRetargeting', () => {
+        console.log('Model loaded for retargeting successfully.')
+
+        // read in mesh2motion engine's retargetable model data (this is the target)
+        const retargetable_meshes: Scene = this.mesh2motion_engine.load_model_step.get_final_retargetable_model_data()
+        const is_valid_skinned_mesh = RetargetUtils.validate_skinned_mesh_has_bones(retargetable_meshes)
+
+        if (is_valid_skinned_mesh) {
+          this.resolve_model_root_bones(retargetable_meshes).catch((error) => {
+            console.error('Error resolving multiple skeletons in model:', error)
+          })
+        }
+      }, { once: true })
+    } catch (error) {
+      console.error('Error loading model:', error)
+      new ModalDialog('Error loading model file.', 'Error').show()
     }
   }
 


### PR DESCRIPTION
Closing the tab lost everything. This saves the loaded model, skeleton setup, bone edits, animation picks, and export and scene settings, then restores them on reload. The retarget page keeps its model and bone mappings too. One commit here is shared with the undo PR since both need quaternion snapshots.