### PR TITLE
Keep original texture bytes when exporting a GLB

### DIFF
--- a/src/lib/processes/export-to-file/GlbTexturePassthroughService.test.ts
+++ b/src/lib/processes/export-to-file/GlbTexturePassthroughService.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi } from 'vitest'
+import { BoxGeometry, Mesh, MeshStandardMaterial, Scene, Texture } from 'three'
+import { GlbTexturePassthroughService } from './GlbTexturePassthroughService'
+import { TextureSourceRegistry } from '../load-model/TextureSourceRegistry'
+
+const GLB_MAGIC = 0x46546C67
+const JSON_CHUNK_TYPE = 0x4E4F534A
+const BIN_CHUNK_TYPE = 0x004E4942
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+interface ParsedGlb {
+  json: Record<string, any[]>
+  bin_bytes: Uint8Array
+}
+
+function parse_glb (glb: ArrayBuffer): ParsedGlb {
+  const view = new DataView(glb)
+  expect(view.getUint32(0, true)).toBe(GLB_MAGIC)
+  expect(view.getUint32(8, true)).toBe(glb.byteLength)
+
+  const json_length = view.getUint32(12, true)
+  expect(view.getUint32(16, true)).toBe(JSON_CHUNK_TYPE)
+  const json = JSON.parse(new TextDecoder().decode(new Uint8Array(glb, 20, json_length)))
+
+  const bin_header = 20 + json_length
+  const bin_length = view.getUint32(bin_header, true)
+  expect(view.getUint32(bin_header + 4, true)).toBe(BIN_CHUNK_TYPE)
+
+  return { json, bin_bytes: new Uint8Array(glb, bin_header + 8, bin_length) }
+}
+
+function build_glb (json: object, bin_bytes: Uint8Array): ArrayBuffer {
+  const encoded_json = new TextEncoder().encode(JSON.stringify(json))
+  const padded_json_length = Math.ceil(encoded_json.byteLength / 4) * 4
+  const padded_bin_length = Math.ceil(bin_bytes.byteLength / 4) * 4
+  const total = 20 + padded_json_length + 8 + padded_bin_length
+
+  const output = new ArrayBuffer(total)
+  const bytes = new Uint8Array(output)
+  const view = new DataView(output)
+
+  view.setUint32(0, GLB_MAGIC, true)
+  view.setUint32(4, 2, true)
+  view.setUint32(8, total, true)
+  view.setUint32(12, padded_json_length, true)
+  view.setUint32(16, JSON_CHUNK_TYPE, true)
+  bytes.fill(0x20, 20 + encoded_json.byteLength, 20 + padded_json_length)
+  bytes.set(encoded_json, 20)
+  view.setUint32(20 + padded_json_length, padded_bin_length, true)
+  view.setUint32(24 + padded_json_length, BIN_CHUNK_TYPE, true)
+  bytes.set(bin_bytes, 28 + padded_json_length)
+
+  return output
+}
+
+/** A texture whose decoded image is irrelevant; only the remembered bytes matter. */
+function make_registered_texture (name: string, bytes: Uint8Array, mime_type: string): Texture {
+  const texture = new Texture()
+  texture.name = name
+  texture.flipY = false
+  TextureSourceRegistry.remember(texture, { bytes, mime_type })
+  return texture
+}
+
+function make_scene (texture: Texture): Scene {
+  const scene = new Scene()
+  const material = new MeshStandardMaterial()
+  material.map = texture
+  scene.add(new Mesh(new BoxGeometry(1, 1, 1), material))
+  return scene
+}
+
+/**
+ * Stands in for a GLTFExporter result: a mesh accessor's buffer view followed by
+ * the re-encoded image, so a replacement of a different length has to shift the
+ * accessor data that comes after it.
+ */
+function make_exported_glb (marker: string, reencoded_image: Uint8Array, accessor_bytes: Uint8Array): ArrayBuffer {
+  const image_offset = Math.ceil(accessor_bytes.byteLength / 4) * 4
+  const bin = new Uint8Array(image_offset + reencoded_image.byteLength)
+  bin.set(accessor_bytes, 0)
+  bin.set(reencoded_image, image_offset)
+
+  const json = {
+    asset: { version: '2.0' },
+    buffers: [{ byteLength: bin.byteLength }],
+    bufferViews: [
+      { buffer: 0, byteOffset: 0, byteLength: accessor_bytes.byteLength, target: 34962 },
+      { buffer: 0, byteOffset: image_offset, byteLength: reencoded_image.byteLength }
+    ],
+    accessors: [{ bufferView: 0, componentType: 5126, count: 1, type: 'VEC3' }],
+    images: [{ bufferView: 1, mimeType: 'image/png' }],
+    textures: [{ sampler: 0, source: 0, name: marker }],
+    samplers: [{}],
+    materials: [{ pbrMetallicRoughness: { baseColorTexture: { index: 0 } } }]
+  }
+
+  return build_glb(json, bin)
+}
+
+describe('GlbTexturePassthroughService', () => {
+  it('marks registered textures and restores their names afterwards', () => {
+    const texture = make_registered_texture('body_diffuse', new Uint8Array([1, 2, 3]), 'image/png')
+    const plan = GlbTexturePassthroughService.prepare_scene(make_scene(texture))
+
+    expect(plan.marked_textures.size).toBe(1)
+    expect(texture.name).not.toBe('body_diffuse')
+
+    plan.restore()
+    expect(texture.name).toBe('body_diffuse')
+  })
+
+  it('skips flipY textures, whose vertical flip the exporter bakes into the pixels', () => {
+    const texture = make_registered_texture('from_fbx', new Uint8Array([1, 2, 3]), 'image/png')
+    texture.flipY = true
+
+    const plan = GlbTexturePassthroughService.prepare_scene(make_scene(texture))
+
+    expect(plan.marked_textures.size).toBe(0)
+    expect(texture.name).toBe('from_fbx')
+  })
+
+  it('skips textures with no remembered source bytes', () => {
+    const texture = new Texture()
+    texture.name = 'generated'
+    texture.flipY = false
+
+    expect(GlbTexturePassthroughService.prepare_scene(make_scene(texture)).marked_textures.size).toBe(0)
+  })
+
+  it('puts the original jpeg bytes back and relocates the buffer views around them', () => {
+    const original_image = new Uint8Array([0xFF, 0xD8, 0xFF, 0xE0, 0x11, 0x22])
+    const texture = make_registered_texture('skin', original_image, 'image/jpeg')
+
+    const plan = GlbTexturePassthroughService.prepare_scene(make_scene(texture))
+    const marker = [...plan.marked_textures.keys()][0]
+
+    const accessor_bytes = new Uint8Array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0, 1, 2])
+    // deliberately a different length from the original, so every later view moves
+    const reencoded_image = new Uint8Array(64).fill(0xAB)
+    const exported = make_exported_glb(marker, reencoded_image, accessor_bytes)
+
+    const result = GlbTexturePassthroughService.apply_original_textures(exported, plan.marked_textures)
+    const { json, bin_bytes } = parse_glb(result)
+
+    expect(json.textures[0].name).toBe('skin')
+    expect(json.images[0].mimeType).toBe('image/jpeg')
+    expect(json.buffers[0].byteLength).toBe(bin_bytes.byteLength)
+
+    const image_view = json.bufferViews[json.images[0].bufferView]
+    expect(image_view.byteLength).toBe(original_image.byteLength)
+    expect([...bin_bytes.subarray(image_view.byteOffset, image_view.byteOffset + image_view.byteLength)])
+      .toEqual([...original_image])
+
+    // the mesh data has to survive the relayout untouched, and stay 4 byte aligned
+    const accessor_view = json.bufferViews[0]
+    expect(accessor_view.byteOffset % 4).toBe(0)
+    expect(accessor_view.target).toBe(34962)
+    expect([...bin_bytes.subarray(accessor_view.byteOffset, accessor_view.byteOffset + accessor_view.byteLength)])
+      .toEqual([...accessor_bytes])
+  })
+
+  it('drops the texture name entirely when the source texture was unnamed', () => {
+    const texture = make_registered_texture('', new Uint8Array([1, 2, 3, 4]), 'image/png')
+    const plan = GlbTexturePassthroughService.prepare_scene(make_scene(texture))
+    const marker = [...plan.marked_textures.keys()][0]
+
+    const exported = make_exported_glb(marker, new Uint8Array(16).fill(0xCD), new Uint8Array([1, 2, 3, 4]))
+    const { json } = parse_glb(GlbTexturePassthroughService.apply_original_textures(exported, plan.marked_textures))
+
+    expect('name' in json.textures[0]).toBe(false)
+  })
+
+  it('leaves a webp original alone when the exporter did not use EXT_texture_webp', () => {
+    const texture = make_registered_texture('webp_map', new Uint8Array([0x52, 0x49, 0x46, 0x46]), 'image/webp')
+    const plan = GlbTexturePassthroughService.prepare_scene(make_scene(texture))
+    const marker = [...plan.marked_textures.keys()][0]
+
+    const reencoded_image = new Uint8Array(16).fill(0xEE)
+    const exported = make_exported_glb(marker, reencoded_image, new Uint8Array([1, 2, 3, 4]))
+    const { json, bin_bytes } = parse_glb(
+      GlbTexturePassthroughService.apply_original_textures(exported, plan.marked_textures))
+
+    // the name still comes back, but the image is untouched
+    expect(json.textures[0].name).toBe('webp_map')
+    expect(json.images[0].mimeType).toBe('image/png')
+    const image_view = json.bufferViews[json.images[0].bufferView]
+    expect([...bin_bytes.subarray(image_view.byteOffset, image_view.byteOffset + image_view.byteLength)])
+      .toEqual([...reencoded_image])
+  })
+
+  it('returns the export untouched when nothing was marked', () => {
+    const exported = make_exported_glb('unused', new Uint8Array([1, 2]), new Uint8Array([3, 4]))
+    expect(GlbTexturePassthroughService.apply_original_textures(exported, new Map())).toBe(exported)
+  })
+})
+
+/**
+ * The unit tests above hand-build an export so the buffer relayout can be checked
+ * precisely. This one goes through the real GLTFExporter to confirm the marker
+ * survives it, which is the assumption the whole approach rests on.
+ */
+describe('GlbTexturePassthroughService against a real GLTFExporter run', () => {
+  it('swaps the exported image for the remembered bytes', async () => {
+    const { GLTFExporter } = await import('three/examples/jsm/exporters/GLTFExporter.js')
+
+    // jsdom has no 2D canvas, so stand in for the re-encode the exporter does. The
+    // bytes it produces are exactly what the passthrough is meant to throw away.
+    const reencoded_image = new Uint8Array(48).fill(0xAB)
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      drawImage: () => {},
+      translate: () => {},
+      scale: () => {}
+    } as unknown as CanvasRenderingContext2D)
+    vi.spyOn(HTMLCanvasElement.prototype, 'toBlob').mockImplementation((callback: BlobCallback) => {
+      callback(new Blob([reencoded_image]))
+    })
+
+    // A 1x1 canvas stands in for a decoded image, since jsdom cannot decode a real one.
+    const canvas = document.createElement('canvas')
+    canvas.width = 1
+    canvas.height = 1
+
+    const original_image = new Uint8Array([0xFF, 0xD8, 0xFF, 0xDB, 0x42, 0x43, 0x44])
+    const texture = new Texture(canvas as unknown as HTMLCanvasElement)
+    texture.name = 'diffuse'
+    texture.flipY = false
+    texture.needsUpdate = true
+    TextureSourceRegistry.remember(texture, { bytes: original_image, mime_type: 'image/jpeg' })
+
+    const scene = make_scene(texture)
+    const plan = GlbTexturePassthroughService.prepare_scene(scene)
+    expect(plan.marked_textures.size).toBe(1)
+
+    const exported = await new GLTFExporter().parseAsync(scene, { binary: true, onlyVisible: false }) as ArrayBuffer
+    plan.restore()
+    expect(texture.name).toBe('diffuse')
+
+    const { json, bin_bytes } = parse_glb(
+      GlbTexturePassthroughService.apply_original_textures(exported, plan.marked_textures))
+
+    expect(json.textures[0].name).toBe('diffuse')
+    expect(json.images[0].mimeType).toBe('image/jpeg')
+
+    const image_view = json.bufferViews[json.images[0].bufferView]
+    expect([...bin_bytes.subarray(image_view.byteOffset, image_view.byteOffset + image_view.byteLength)])
+      .toEqual([...original_image])
+
+    // every accessor must still land on a valid, aligned slice of the rebuilt buffer
+    json.accessors.forEach((accessor: { bufferView: number }) => {
+      const view = json.bufferViews[accessor.bufferView]
+      expect(view.byteOffset % 4).toBe(0)
+      expect(view.byteOffset + view.byteLength).toBeLessThanOrEqual(bin_bytes.byteLength)
+    })
+
+    vi.restoreAllMocks()
+  })
+})

--- a/src/lib/processes/export-to-file/GlbTexturePassthroughService.ts
+++ b/src/lib/processes/export-to-file/GlbTexturePassthroughService.ts
@@ -1,0 +1,351 @@
+import { type Object3D, type Texture } from 'three'
+import { TextureSourceRegistry, type EncodedTextureSource } from '../load-model/TextureSourceRegistry'
+
+export interface MarkedTexture extends EncodedTextureSource {
+  original_name: string
+}
+
+/**
+ * The markers assigned before an export, plus the undo for the texture renaming.
+ */
+/** The parts of the exported glTF JSON this rewrites. */
+interface GlbBufferViewDef {
+  buffer?: number
+  byteOffset?: number
+  byteLength: number
+}
+
+interface GlbImageDef {
+  bufferView?: number
+  mimeType?: string
+}
+
+interface GlbTextureDef {
+  name?: string
+  source?: number
+  extensions?: { EXT_texture_webp?: { source?: number } }
+}
+
+interface GlbJson {
+  buffers?: Array<{ byteLength?: number }>
+  bufferViews?: GlbBufferViewDef[]
+  images?: GlbImageDef[]
+  textures?: GlbTextureDef[]
+}
+
+export interface TexturePassthroughPlan {
+  marked_textures: Map<string, MarkedTexture>
+  restore: () => void
+}
+
+/**
+ * Puts the original, untouched image bytes back into an exported GLB.
+ *
+ * GLTFExporter cannot re-use the bytes a texture came from, because by the time it
+ * runs three only has the decoded pixels. It redraws every texture into a 2D canvas
+ * and re-encodes it, which loses quality (see {@link TextureSourceRegistry}). This
+ * service swaps the re-encoded images back out for the originals afterwards.
+ *
+ * Matching the two up is done with a marker name: `prepare_scene` renames every
+ * eligible texture, GLTFExporter copies `texture.name` into the exported
+ * `textures[i].name`, and `apply_original_textures` uses that to find which image
+ * each original belongs to before restoring the real name.
+ *
+ * The marker doubles as a safety check. Whenever the exporter has to *derive* a new
+ * texture rather than write one straight through - combining metalness and roughness
+ * into one map, flipping a normal map channel, decompressing a KTX2 texture - it
+ * builds a brand new Texture object that never carries a marker, so those are left
+ * alone automatically.
+ */
+export class GlbTexturePassthroughService {
+  private static readonly MARKER_PREFIX = '__m2m_texture_source_'
+  private static readonly MARKER_SUFFIX = '__'
+
+  private static readonly GLB_HEADER_BYTES = 12
+  private static readonly CHUNK_HEADER_BYTES = 8
+  private static readonly GLB_MAGIC = 0x46546C67 // 'glTF'
+  private static readonly JSON_CHUNK_TYPE = 0x4E4F534A // 'JSON'
+  private static readonly BIN_CHUNK_TYPE = 0x004E4942 // 'BIN\0'
+
+  /** Formats glTF allows as a plain image, with no extension declaration needed. */
+  private static readonly CORE_MIME_TYPES = ['image/png', 'image/jpeg']
+
+  /**
+   * Marks every texture in the scene whose original bytes we still have.
+   *
+   * @param root the scene about to be handed to GLTFExporter
+   * @returns the markers to feed to {@link apply_original_textures}, and a
+   * `restore` that puts the real texture names back. `restore` must run whether
+   * the export succeeds or fails, since it mutates the live scene textures.
+   */
+  public static prepare_scene (root: Object3D): TexturePassthroughPlan {
+    const marked_textures = new Map<string, MarkedTexture>()
+    const renamed: Array<{ texture: Texture, original_name: string }> = []
+    const seen = new Set<Texture>()
+
+    root.traverse((node) => {
+      this.collect_materials(node).forEach((material) => {
+        Object.values(material).forEach((value) => {
+          const texture = this.as_texture(value)
+          if (texture === null || seen.has(texture)) {
+            return
+          }
+          seen.add(texture)
+
+          const source = TextureSourceRegistry.get(texture)
+          if (source === undefined) {
+            return
+          }
+
+          // A flipY texture (anything imported from FBX or Collada) has its vertical
+          // flip baked into the exported pixels by GLTFExporter, because glTF has no
+          // flipY flag. The original bytes are upside down relative to that, so they
+          // cannot be passed through.
+          if (texture.flipY) {
+            return
+          }
+
+          const marker = `${this.MARKER_PREFIX}${marked_textures.size}${this.MARKER_SUFFIX}`
+          marked_textures.set(marker, { ...source, original_name: texture.name })
+          renamed.push({ texture, original_name: texture.name })
+          texture.name = marker
+        })
+      })
+    })
+
+    return {
+      marked_textures,
+      restore: () => {
+        renamed.forEach((entry) => {
+          entry.texture.name = entry.original_name
+        })
+      }
+    }
+  }
+
+  /**
+   * @param glb a binary glTF as produced by GLTFExporter
+   * @param marked_textures the map returned by {@link prepare_scene}
+   * @returns a new GLB with the re-encoded images replaced by their originals, or
+   * the original buffer untouched when there is nothing to swap
+   */
+  public static apply_original_textures (glb: ArrayBuffer, marked_textures: Map<string, MarkedTexture>): ArrayBuffer {
+    if (marked_textures.size === 0) {
+      return glb
+    }
+
+    const parsed = this.parse_glb(glb)
+    if (parsed === null) {
+      return glb
+    }
+
+    const { json, bin_bytes } = parsed
+    const replacements = this.plan_replacements(json, marked_textures)
+
+    // The texture names were rewritten to markers either way, so the JSON always has
+    // to be written back out even when no image ended up being replaced.
+    if (replacements === null) {
+      return this.write_glb(json, bin_bytes)
+    }
+
+    return this.write_glb(json, this.rebuild_bin_chunk(json, bin_bytes, replacements))
+  }
+
+  /**
+   * Restores the real texture names and works out which buffer views hold an image
+   * that can be swapped for its original.
+   *
+   * @returns buffer view index -> replacement bytes, or null when nothing is
+   * replaceable
+   */
+  private static plan_replacements (json: GlbJson, marked_textures: Map<string, MarkedTexture>): Map<number, Uint8Array> | null {
+    const texture_defs: GlbTextureDef[] = json.textures ?? []
+    const image_defs: GlbImageDef[] = json.images ?? []
+    const buffer_views: GlbBufferViewDef[] = json.bufferViews ?? []
+
+    // A single buffer is all GLTFExporter ever writes for a GLB. Anything else means
+    // the layout is not what rebuild_bin_chunk assumes, so leave the images alone.
+    const single_buffer = buffer_views.every((view) => (view.buffer ?? 0) === 0)
+
+    const replacements = new Map<number, Uint8Array>()
+
+    texture_defs.forEach((texture_def) => {
+      const marked = texture_def.name === undefined ? undefined : marked_textures.get(texture_def.name)
+      if (marked === undefined) {
+        return
+      }
+
+      if (marked.original_name === '') {
+        delete texture_def.name
+      } else {
+        texture_def.name = marked.original_name
+      }
+
+      if (!single_buffer) {
+        return
+      }
+
+      const image_index = this.source_index_for_texture(texture_def, marked.mime_type)
+      const image_def = image_index === undefined ? undefined : image_defs[image_index]
+
+      // Only ever swap an image the exporter embedded in the binary chunk, and never
+      // one another texture already claimed.
+      if (typeof image_def?.bufferView !== 'number' || replacements.has(image_def.bufferView)) {
+        return
+      }
+
+      image_def.mimeType = marked.mime_type
+      replacements.set(image_def.bufferView, marked.bytes)
+    })
+
+    return replacements.size === 0 ? null : replacements
+  }
+
+  /**
+   * Finds the image a texture reads from, refusing any pairing that would change
+   * which extensions the file depends on.
+   *
+   * A png or jpeg original is always safe: both are core glTF and sit in `source`.
+   * A webp original is only safe when the exporter already routed this texture
+   * through EXT_texture_webp, so the extension is declared either way.
+   */
+  private static source_index_for_texture (texture_def: GlbTextureDef, mime_type: string): number | undefined {
+    const webp_source = texture_def.extensions?.EXT_texture_webp?.source
+
+    if (mime_type === 'image/webp') {
+      return typeof webp_source === 'number' ? webp_source : undefined
+    }
+
+    if (!this.CORE_MIME_TYPES.includes(mime_type) || webp_source !== undefined) {
+      return undefined
+    }
+
+    return typeof texture_def.source === 'number' ? texture_def.source : undefined
+  }
+
+  /**
+   * Rewrites the binary chunk with the replacement images in place.
+   *
+   * Swapping an image changes its length, so every later buffer view moves. Each
+   * view is copied out in index order and re-laid-out on a 4 byte boundary, which is
+   * the alignment glTF requires of accessor data and the same one GLTFExporter uses.
+   */
+  private static rebuild_bin_chunk (json: GlbJson, bin_bytes: Uint8Array, replacements: Map<number, Uint8Array>): Uint8Array {
+    const buffer_views: GlbBufferViewDef[] = json.bufferViews ?? []
+
+    const segments: Uint8Array[] = buffer_views.map((view, index) => {
+      const replacement = replacements.get(index)
+      if (replacement !== undefined) {
+        return replacement
+      }
+
+      const byte_offset: number = view.byteOffset ?? 0
+      return bin_bytes.subarray(byte_offset, byte_offset + view.byteLength)
+    })
+
+    let total_length = 0
+    const offsets: number[] = segments.map((segment) => {
+      const offset = total_length
+      total_length += Math.ceil(segment.byteLength / 4) * 4
+      return offset
+    })
+
+    const rebuilt = new Uint8Array(total_length)
+    segments.forEach((segment, index) => {
+      rebuilt.set(segment, offsets[index])
+      buffer_views[index].byteOffset = offsets[index]
+      buffer_views[index].byteLength = segment.byteLength
+    })
+
+    if (json.buffers?.[0] != null) {
+      json.buffers[0].byteLength = total_length
+    }
+
+    return rebuilt
+  }
+
+  private static parse_glb (glb: ArrayBuffer): { json: GlbJson, bin_bytes: Uint8Array } | null {
+    const header_and_chunk = this.GLB_HEADER_BYTES + this.CHUNK_HEADER_BYTES
+    if (glb.byteLength < header_and_chunk) {
+      return null
+    }
+
+    const view = new DataView(glb)
+    if (view.getUint32(0, true) !== this.GLB_MAGIC) {
+      return null
+    }
+
+    // the JSON chunk is required to be first in a GLB
+    const json_length = view.getUint32(this.GLB_HEADER_BYTES, true)
+    const json_start = header_and_chunk
+    if (view.getUint32(this.GLB_HEADER_BYTES + 4, true) !== this.JSON_CHUNK_TYPE ||
+      json_start + json_length > glb.byteLength) {
+      return null
+    }
+
+    const json = JSON.parse(new TextDecoder().decode(new Uint8Array(glb, json_start, json_length))) as GlbJson
+
+    const bin_header_start = json_start + json_length
+    if (bin_header_start + this.CHUNK_HEADER_BYTES > glb.byteLength) {
+      return null
+    }
+
+    const bin_length = view.getUint32(bin_header_start, true)
+    const bin_start = bin_header_start + this.CHUNK_HEADER_BYTES
+    if (view.getUint32(bin_header_start + 4, true) !== this.BIN_CHUNK_TYPE ||
+      bin_start + bin_length > glb.byteLength) {
+      return null
+    }
+
+    return { json, bin_bytes: new Uint8Array(glb, bin_start, bin_length) }
+  }
+
+  private static write_glb (json: GlbJson, bin_bytes: Uint8Array): ArrayBuffer {
+    const encoded_json = new TextEncoder().encode(JSON.stringify(json))
+
+    // the spec pads the JSON chunk to 4 bytes with spaces and the binary chunk with zeros
+    const padded_json_length = Math.ceil(encoded_json.byteLength / 4) * 4
+    const padded_bin_length = Math.ceil(bin_bytes.byteLength / 4) * 4
+
+    const json_start = this.GLB_HEADER_BYTES + this.CHUNK_HEADER_BYTES
+    const bin_header_start = json_start + padded_json_length
+    const bin_start = bin_header_start + this.CHUNK_HEADER_BYTES
+    const total_length = bin_start + padded_bin_length
+
+    const output = new ArrayBuffer(total_length)
+    const output_bytes = new Uint8Array(output)
+    const output_view = new DataView(output)
+
+    output_view.setUint32(0, this.GLB_MAGIC, true)
+    output_view.setUint32(4, 2, true) // glTF version
+    output_view.setUint32(8, total_length, true)
+
+    output_view.setUint32(this.GLB_HEADER_BYTES, padded_json_length, true)
+    output_view.setUint32(this.GLB_HEADER_BYTES + 4, this.JSON_CHUNK_TYPE, true)
+    output_bytes.fill(0x20, json_start + encoded_json.byteLength, bin_header_start)
+    output_bytes.set(encoded_json, json_start)
+
+    output_view.setUint32(bin_header_start, padded_bin_length, true)
+    output_view.setUint32(bin_header_start + 4, this.BIN_CHUNK_TYPE, true)
+    output_bytes.set(bin_bytes, bin_start)
+
+    return output
+  }
+
+  private static as_texture (value: unknown): Texture | null {
+    if (typeof value !== 'object' || value === null || (value as Texture).isTexture !== true) {
+      return null
+    }
+    return value as Texture
+  }
+
+  private static collect_materials (node: Object3D): Array<Record<string, unknown>> {
+    const material = (node as Object3D & { material?: unknown }).material
+    if (material == null || typeof material !== 'object') {
+      return []
+    }
+
+    const material_list = Array.isArray(material) ? material : [material]
+    return material_list.filter((entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null)
+  }
+}

--- a/src/lib/processes/export-to-file/StepExportToFile.ts
+++ b/src/lib/processes/export-to-file/StepExportToFile.ts
@@ -7,6 +7,7 @@ import { ExportBoneNamingService } from './ExportBoneNamingService.ts'
 import { ExportHierarchyService } from './ExportHierarchyService.ts'
 import { ExportAnimationCleanupService } from './ExportAnimationCleanupService.ts'
 import { GlbSkinCleanupService } from './GlbSkinCleanupService.ts'
+import { GlbTexturePassthroughService, type TexturePassthroughPlan } from './GlbTexturePassthroughService.ts'
 import { AnimationUtility } from '../animations-listing/AnimationUtility.ts'
 import { type AnimationExportSelection } from '../animations-listing/interfaces/AnimationExportSelection.ts'
 import { FbxTextureCompatibilityService } from './FbxTextureCompatibilityService.ts'
@@ -142,6 +143,23 @@ export class StepExportToFile extends EventTarget {
   }
 
   public async export_glb (exported_scene: Scene, animations_to_export: AnimationClip[], file_name: string): Promise<void> {
+    // GLTFExporter re-encodes every texture through a 2D canvas, which is lossy.
+    // Marking the textures here lets the original image bytes be put back afterwards.
+    const texture_passthrough = GlbTexturePassthroughService.prepare_scene(exported_scene)
+
+    try {
+      await this.parse_and_save_glb(exported_scene, animations_to_export, file_name, texture_passthrough)
+    } finally {
+      texture_passthrough.restore()
+    }
+  }
+
+  private async parse_and_save_glb (
+    exported_scene: Scene,
+    animations_to_export: AnimationClip[],
+    file_name: string,
+    texture_passthrough: TexturePassthroughPlan
+  ): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       const gltf_exporter = new GLTFExporter()
 
@@ -158,7 +176,9 @@ export class StepExportToFile extends EventTarget {
           // Handle the result of the export
           if (result !== null) {
             const cleaned_result = GlbSkinCleanupService.remove_skin_skeleton_properties(result)
-            this.save_array_buffer(cleaned_result, `${file_name}.glb`)
+            const original_textures_result = GlbTexturePassthroughService.apply_original_textures(
+              cleaned_result, texture_passthrough.marked_textures)
+            this.save_array_buffer(original_textures_result, `${file_name}.glb`)
             resolve() // Resolve the promise when the export is complete
           } else {
             console.log('ERROR: result is not an instance of ArrayBuffer')

--- a/src/lib/processes/load-model/CustomGLTFLoader.ts
+++ b/src/lib/processes/load-model/CustomGLTFLoader.ts
@@ -3,6 +3,7 @@ import { EventDispatcher } from 'three'
 import { type GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 import { type Scene } from 'three/src/scenes/Scene.js'
 import { ModalDialog } from '../../ModalDialog'
+import { TextureSourceRegistry } from './TextureSourceRegistry'
 
 /**
  * Loads a GLTF (with BIN and textures) from a ZIP file buffer, using in-memory URLs for all assets.
@@ -50,9 +51,14 @@ export class CustomGLTFLoader extends EventDispatcher {
 
       // Load the GLTF from the in-memory URL
       this.loader.load(gltf_url, (gltf) => {
-        const loaded_scene: Scene = gltf.scene
-        onLoad(loaded_scene)
-        URL.revokeObjectURL(gltf_url)
+        // Keep the original compressed texture bytes around so exporting the model
+        // again does not push them through a lossy canvas re-encode.
+        TextureSourceRegistry.capture_from_gltf(gltf)
+          .finally(() => {
+            const loaded_scene: Scene = gltf.scene
+            onLoad(loaded_scene)
+            URL.revokeObjectURL(gltf_url)
+          })
       },
       undefined,
       (err) => {

--- a/src/lib/processes/load-model/StepLoadModel.ts
+++ b/src/lib/processes/load-model/StepLoadModel.ts
@@ -10,6 +10,7 @@ import { BufferGeometry, Group, type Material, type Object3D } from 'three'
 import { ModalDialog } from '../../ModalDialog.ts'
 import { Utility } from '../../Utilities.ts'
 import { ModelCleanupUtility } from './ModelCleanupUtility.ts'
+import { TextureSourceRegistry } from './TextureSourceRegistry.ts'
 import { ModelAnalysisReport, type ModelImportAnalysis, type SceneSnapshot } from './ModelAnalysisReport.ts'
 import { PlatformUtils } from '../../PlatformUtils.ts'
 
@@ -209,8 +210,13 @@ export class StepLoadModel extends EventTarget {
       this.load_fbx_file(model_file_path)
     } else if (file_extension === 'glb') {
       this.gltf_loader.load(model_file_path as string, (gltf) => {
-        const loaded_scene: Scene = gltf.scene
-        this.process_loaded_scene(loaded_scene)
+        // Keep the original compressed texture bytes around so exporting the model
+        // again does not push them through a lossy canvas re-encode.
+        TextureSourceRegistry.capture_from_gltf(gltf)
+          .finally(() => {
+            const loaded_scene: Scene = gltf.scene
+            this.process_loaded_scene(loaded_scene)
+          })
       })
     } else if (file_extension === 'zip') {
       console.log('ZIP file can contain GLTF+BIN model data')

--- a/src/lib/processes/load-model/TextureSourceRegistry.ts
+++ b/src/lib/processes/load-model/TextureSourceRegistry.ts
@@ -1,0 +1,166 @@
+import { type Texture } from 'three'
+import { type GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js'
+
+/**
+ * The compressed bytes a texture was originally decoded from, plus the mime type
+ * that describes them.
+ */
+export interface EncodedTextureSource {
+  bytes: Uint8Array
+  mime_type: string
+}
+
+/** The parts of the glTF JSON and of GLTFLoader's parser this needs, which three does not type. */
+interface GltfImageDef {
+  uri?: string
+  mimeType?: string
+  bufferView?: number
+}
+
+interface GltfTextureDef {
+  source?: number
+  extensions?: { EXT_texture_webp?: { source?: number } }
+}
+
+interface GltfParserLike {
+  json?: { images?: GltfImageDef[], textures?: GltfTextureDef[] }
+  associations?: Map<object, { textures?: number }>
+  options?: { manager?: { resolveURL?: (url: string) => string } }
+  getDependency: (type: string, index: number) => Promise<ArrayBuffer>
+}
+
+/**
+ * Remembers the original compressed image bytes behind an imported texture.
+ *
+ * Once a texture is loaded, three only keeps the *decoded* pixels (an ImageBitmap).
+ * GLTFExporter therefore has to re-encode every texture through a 2D canvas on the
+ * way out, which is lossy in three separate ways:
+ *
+ *   - a JPEG source is re-compressed at the browser's default quality (~0.92 in
+ *     Blink), so every rig-and-export round trip adds another generation of
+ *     blocking and ringing artifacts
+ *   - `drawImage` into a 2D canvas round-trips through premultiplied alpha, which
+ *     quantises the colour of any partially transparent texel and zeroes the colour
+ *     of fully transparent ones (dark fringes around cut-out edges)
+ *   - a palette PNG comes back out as full RGBA, inflating the file for no gain
+ *
+ * Keeping the source bytes lets {@link GlbTexturePassthroughService} put the exact
+ * original image back into the exported GLB instead of the re-encoded one.
+ *
+ * A WeakMap is used rather than `texture.userData` because userData is deep-cloned
+ * through `JSON.stringify` by both `Texture.copy` and GLTFExporter's extras
+ * serialisation, neither of which survives a Uint8Array.
+ */
+export class TextureSourceRegistry {
+  private static readonly sources = new WeakMap<Texture, EncodedTextureSource>()
+
+  public static remember (texture: Texture, source: EncodedTextureSource): void {
+    this.sources.set(texture, source)
+  }
+
+  public static get (texture: Texture): EncodedTextureSource | undefined {
+    return this.sources.get(texture)
+  }
+
+  /**
+   * Records the source bytes for every texture in a freshly loaded glTF/GLB.
+   *
+   * Failures are swallowed per texture: a missing source only means that texture
+   * falls back to the re-encoded image, which is what happened before this existed.
+   */
+  public static async capture_from_gltf (gltf: GLTF): Promise<void> {
+    const parser = (gltf as unknown as { parser?: GltfParserLike }).parser
+    const json = parser?.json
+
+    if (parser?.associations == null || !Array.isArray(json?.images) || !Array.isArray(json?.textures)) {
+      return
+    }
+
+    const pending: Array<Promise<void>> = []
+
+    parser.associations.forEach((mapping, key) => {
+      const texture = key as Texture
+      if (texture?.isTexture !== true || typeof mapping?.textures !== 'number') {
+        return
+      }
+
+      const image_index = this.source_index_for_texture(json.textures?.[mapping.textures])
+      if (image_index === undefined) {
+        return
+      }
+
+      pending.push(this.capture_single_image(parser, json.images?.[image_index], texture))
+    })
+
+    await Promise.all(pending)
+  }
+
+  /**
+   * glTF stores webp images behind EXT_texture_webp rather than the plain
+   * `source` property, so both spellings have to be checked.
+   */
+  private static source_index_for_texture (texture_def: GltfTextureDef | undefined): number | undefined {
+    if (typeof texture_def?.source === 'number') {
+      return texture_def.source
+    }
+
+    const webp_source = texture_def?.extensions?.EXT_texture_webp?.source
+    return typeof webp_source === 'number' ? webp_source : undefined
+  }
+
+  private static async capture_single_image (
+    parser: GltfParserLike,
+    image_def: GltfImageDef | undefined,
+    texture: Texture
+  ): Promise<void> {
+    if (image_def == null) {
+      return
+    }
+
+    try {
+      const bytes = await this.read_image_bytes(parser, image_def)
+      const mime_type: string | null = image_def.mimeType ?? this.mime_type_from_uri(image_def.uri)
+
+      if (bytes != null && bytes.byteLength > 0 && mime_type != null) {
+        this.remember(texture, { bytes, mime_type })
+      }
+    } catch (error) {
+      console.warn('Could not keep the original bytes for a texture, it will be re-encoded on export:', error)
+    }
+  }
+
+  private static async read_image_bytes (parser: GltfParserLike, image_def: GltfImageDef): Promise<Uint8Array | null> {
+    if (typeof image_def.bufferView === 'number') {
+      return new Uint8Array(await parser.getDependency('bufferView', image_def.bufferView))
+    }
+
+    if (typeof image_def.uri !== 'string') {
+      return null
+    }
+
+    // Resolving through the LoadingManager applies the same URL modifier the ZIP
+    // loader installs, so images that live inside an uploaded archive resolve to
+    // their in-memory blob instead of a 404.
+    const resolved_url = parser.options?.manager?.resolveURL?.(image_def.uri) ?? image_def.uri
+    const response = await fetch(resolved_url)
+    return new Uint8Array(await response.arrayBuffer())
+  }
+
+  private static mime_type_from_uri (uri: string | undefined): string | null {
+    if (uri === undefined) {
+      return null
+    }
+
+    const data_uri_match = /^data:(image\/[^;,]+)/i.exec(uri)
+    if (data_uri_match != null) {
+      return data_uri_match[1].toLowerCase()
+    }
+
+    const extension = /\.(png|jpe?g|webp)(?:[?#]|$)/i.exec(uri)?.[1].toLowerCase()
+    if (extension === undefined) {
+      return null
+    }
+
+    return extension === 'jpg' || extension === 'jpeg' ? 'image/jpeg' : `image/${extension}`
+  }
+}

--- a/src/retarget/steps/StepExportRetargetedAnimations.ts
+++ b/src/retarget/steps/StepExportRetargetedAnimations.ts
@@ -9,6 +9,7 @@ import { ExportBoneNamingService } from '../../lib/processes/export-to-file/Expo
 import { ExportHierarchyService } from '../../lib/processes/export-to-file/ExportHierarchyService'
 import { ExportAnimationCleanupService } from '../../lib/processes/export-to-file/ExportAnimationCleanupService'
 import { GlbSkinCleanupService } from '../../lib/processes/export-to-file/GlbSkinCleanupService'
+import { GlbTexturePassthroughService, type TexturePassthroughPlan } from '../../lib/processes/export-to-file/GlbTexturePassthroughService'
 import { FbxTextureCompatibilityService } from '../../lib/processes/export-to-file/FbxTextureCompatibilityService'
 
 export class StepExportRetargetedAnimations extends EventTarget {
@@ -124,6 +125,23 @@ export class StepExportRetargetedAnimations extends EventTarget {
   }
 
   public async export_glb (exported_scene: Scene, animations_to_export: AnimationClip[], file_name: string): Promise<void> {
+    // GLTFExporter re-encodes every texture through a 2D canvas, which is lossy.
+    // Marking the textures here lets the original image bytes be put back afterwards.
+    const texture_passthrough = GlbTexturePassthroughService.prepare_scene(exported_scene)
+
+    try {
+      await this.parse_and_save_glb(exported_scene, animations_to_export, file_name, texture_passthrough)
+    } finally {
+      texture_passthrough.restore()
+    }
+  }
+
+  private async parse_and_save_glb (
+    exported_scene: Scene,
+    animations_to_export: AnimationClip[],
+    file_name: string,
+    texture_passthrough: TexturePassthroughPlan
+  ): Promise<void> {
     await new Promise<void>((resolve, reject) => {
       const gltf_exporter = new GLTFExporter()
 
@@ -140,7 +158,9 @@ export class StepExportRetargetedAnimations extends EventTarget {
           // Handle the result of the export
           if (result instanceof ArrayBuffer) {
             const cleaned_result = GlbSkinCleanupService.remove_skin_skeleton_properties(result)
-            this.save_array_buffer(cleaned_result, `${file_name}.glb`)
+            const original_textures_result = GlbTexturePassthroughService.apply_original_textures(
+              cleaned_result, texture_passthrough.marked_textures)
+            this.save_array_buffer(original_textures_result, `${file_name}.glb`)
             resolve() // Resolve the promise when the export is complete
           } else {
             console.log('ERROR: result is not an instance of ArrayBuffer')


### PR DESCRIPTION
#148 exported model contains png texture which is larger than original, for jpeg also quality seems lower

### Root cause: 
GLTFExporter cannot re-use the bytes a texture came from. Once a model is loaded three only keeps the decoded pixels, so on export it redraws every texture into a 2D canvas and re-encodes it. That loses quality three ways:

- a JPEG source is re-compressed at the browser's default quality (~0.92 in Blink), so every rig-and-export round trip adds another generation of blocking and ringing artifacts
- drawImage round-trips through premultiplied alpha, quantising the colour of partially transparent texels and zeroing fully transparent ones, which shows up as dark fringes around cut-out edges
- a palette PNG comes back out as full RGBA, inflating the file for no gain

<img width="1154" height="1036" alt="jpeg-generation-loss" src="https://github.com/user-attachments/assets/7574eb7c-b6a6-4ba3-8b18-d1ccdc3f321a" />


### Solution:
TextureSourceRegistry remembers the compressed bytes behind each imported texture, and GlbTexturePassthroughService puts them back into the exported GLB in place of the re-encoded image, relaying out the binary chunk around the new lengths.

The two are matched with a marker name: textures are renamed before the export, GLTFExporter copies texture.name into textures[i].name, and the marker is used afterwards to find the right image before the real name is restored. That doubles as the safety check, since every texture the exporter derives rather than writes straight through - a combined metalness/roughness map, a flipped normal map, a decompressed KTX2 texture - is a new Texture object that never carries a marker.

Textures imported from FBX or Collada are skipped as well: glTF has no flipY flag, so the exporter bakes the vertical flip into the pixels and the original bytes are upside down relative to that. A webp original is only substituted when the exporter already routed the texture through EXT_texture_webp, so the extensions the file depends on never change.

### Before opening this pull request

Please discuss the problem and proposed approach in the Mesh2Motion Discord (https://discord.gg/UChE936q7y) before submitting code. This project receives a too many untested changes, so discussion helps me confirm that:

- The problem is real and affects the project or its users.
- The approach is consistent with the existing workflow and project direction.
- The change is small enough to review and maintain.


### When later doing the pull request

Make sure to include these type of details

- **Description on the current problem, and your proposed solution**
- **Steps to reproduce the bug, or use the new feature**


### Checklist before submitting

- [ ] I discussed the problem and proposed approach in Discord.
- [ ] I have provided enough context for someone else to reproduce and review the change.
- [ ] I have kept this pull request focused and removed unrelated changes.
- [ ] I tested the original reproduction steps and confirmed the problem is fixed.
- [ ] I understand that incomplete, untested, or unexplained pull requests may be closed without review.
