### PR TITLE
Add front/back plane correction for hair weighted to the arms

### DIFF
--- a/src/Mesh2MotionEngine.ts
+++ b/src/Mesh2MotionEngine.ts
@@ -634,6 +634,12 @@ export class Mesh2MotionEngine {
       this.edit_skeleton_step.get_arm_plane_offset()
     )
 
+    // Pass front/back plane correction settings to the weight skin step
+    this.weight_skin_step.set_depth_plane_correction_settings(
+      this.edit_skeleton_step.use_depth_plane_correction(),
+      this.edit_skeleton_step.get_depth_plane_distance()
+    )
+
     this.weight_skin_step.create_binding_skeleton()
 
     // add geometry data needed for skinning
@@ -675,6 +681,12 @@ export class Mesh2MotionEngine {
     this.weight_skin_step.set_arm_plane_correction_settings(
       this.edit_skeleton_step.use_arm_plane_correction(),
       this.edit_skeleton_step.get_arm_plane_offset()
+    )
+
+    // Pass front/back plane correction settings to the weight skin step
+    this.weight_skin_step.set_depth_plane_correction_settings(
+      this.edit_skeleton_step.use_depth_plane_correction(),
+      this.edit_skeleton_step.get_depth_plane_distance()
     )
   }
 

--- a/src/create.html
+++ b/src/create.html
@@ -298,7 +298,7 @@
           </div>
 
           <!-- Arm plane controls -->
-          <div id="use-arm-plane-container" style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+          <div id="use-arm-plane-container" style="display: flex; flex-direction: column; gap: 0.5rem;">
             <div class="styled-checkbox">
               <input type="checkbox" id="arm-plane-checkbox" />
               <label for="arm-plane-checkbox">Use Arm Plane Correction</label>
@@ -310,6 +310,22 @@
               <label for="arm-plane-offset-input">Distance:</label>
               <input type="range" id="arm-plane-offset-input" min="-0.10" max="0.10" step="0.001" value="0.00" />
               <span id="arm-plane-offset-label" style="width: 3.5rem;">0.0%</span>
+            </div>
+          </div>
+
+          <!-- Front/back plane controls -->
+          <div id="use-depth-plane-container" style="display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 1rem;">
+            <div class="styled-checkbox">
+              <input type="checkbox" id="depth-plane-checkbox" />
+              <label for="depth-plane-checkbox">Use Front/Back Plane Correction</label>
+
+              <img data-tippy-content="If long hair, a cape, or other geometry in front of or behind the body is moving with the arms, use a pair of dividers to define how deep the arm area is." src="images/icons/help.svg" alt="Help" width="20" height="20" />
+
+            </div>
+            <div id="depth-plane-setting-container" style="display: flex; align-items: center; gap: 0.5rem;">
+              <label for="depth-plane-distance-input">Depth:</label>
+              <input type="range" id="depth-plane-distance-input" min="0.02" max="0.40" step="0.005" value="0.10" />
+              <span id="depth-plane-distance-label" style="width: 3.5rem;">10.0%</span>
             </div>
           </div>
 

--- a/src/lib/UI.ts
+++ b/src/lib/UI.ts
@@ -67,6 +67,11 @@ export class UI {
   dom_arm_plane_offset_input: HTMLInputElement | null = null
   dom_arm_plane_offset_label: HTMLElement | null = null
   dom_arm_plane_setting_container: HTMLElement | null = null
+  dom_use_depth_plane_container: HTMLElement | null = null
+  dom_depth_plane_checkbox: HTMLInputElement | null = null
+  dom_depth_plane_distance_input: HTMLInputElement | null = null
+  dom_depth_plane_distance_label: HTMLElement | null = null
+  dom_depth_plane_setting_container: HTMLElement | null = null
 
   dom_skinned_mesh_tools: HTMLElement | null = null
   dom_skinned_mesh_animation_tools: HTMLElement | null = null
@@ -197,6 +202,11 @@ export class UI {
     this.dom_arm_plane_offset_input = document.querySelector('#arm-plane-offset-input')
     this.dom_arm_plane_offset_label = document.querySelector('#arm-plane-offset-label')
     this.dom_arm_plane_setting_container = document.querySelector('#arm-plane-setting-container')
+    this.dom_use_depth_plane_container = document.querySelector('#use-depth-plane-container')
+    this.dom_depth_plane_checkbox = document.querySelector('#depth-plane-checkbox')
+    this.dom_depth_plane_distance_input = document.querySelector('#depth-plane-distance-input')
+    this.dom_depth_plane_distance_label = document.querySelector('#depth-plane-distance-label')
+    this.dom_depth_plane_setting_container = document.querySelector('#depth-plane-setting-container')
 
     this.dom_bind_pose_button = document.querySelector('#action_bind_pose')
     // this.dom_scale_skeleton_input_box = document.querySelector('#scale-input')

--- a/src/lib/processes/edit-skeleton/DepthPlaneManager.ts
+++ b/src/lib/processes/edit-skeleton/DepthPlaneManager.ts
@@ -1,0 +1,148 @@
+import { Group, Mesh, PlaneGeometry, MeshBasicMaterial, type Scene, DoubleSide } from 'three'
+
+/**
+ * DepthPlaneManager - manages the pair of mirrored planes that show where the
+ * front/back weight correction cuts off during the edit skeleton step.
+ *
+ * The same shape as ArmPlaneManager, but the planes face along Z instead of X:
+ * one in front of the character and one behind, so the user can see how much
+ * hair or clothing depth is about to be taken off the arm bones.
+ */
+export class DepthPlaneManager {
+  private readonly depth_plane_group_name: string = 'depth_plane_group'
+
+  // State tracking
+  private scene_ref: Scene | null = null
+  private plane_group: Group | null = null
+  private front_plane_mesh: Mesh | null = null
+  private back_plane_mesh: Mesh | null = null
+  private current_plane_z: number = 0.0
+  private current_center_y: number = 0.0
+  private current_anchor_z: number = 0.0
+  private readonly plane_size: number = 2.0
+  private is_visible: boolean = false
+
+  /**
+   * Initialize the manager with a scene reference
+   * @param scene The main scene
+   */
+  public initialize (scene: Scene): void {
+    this.scene_ref = scene
+  }
+
+  /**
+   * Set the visibility of the depth planes. Creates them on demand and removes
+   * them when hidden, so nothing lingers in the scene between steps.
+   */
+  public set_visibility (visible: boolean): void {
+    if (visible && !this.is_visible) {
+      this.add_planes()
+    } else if (!visible && this.is_visible) {
+      this.remove_planes()
+    }
+  }
+
+  /**
+   * Move the planes to a new distance either side of the body's depth. They are
+   * centered on the shoulder joint's height so they sit over the torso.
+   *
+   * State is stored even when the planes are hidden, so callers can update the
+   * position before or after toggling visibility.
+   *
+   * @param plane_z how far in front of and behind the anchor the planes sit
+   * @param center_y the height to center the planes at
+   * @param anchor_z the body depth the distance is measured out from
+   */
+  public update_position (plane_z: number, center_y: number, anchor_z: number): void {
+    this.current_plane_z = plane_z
+    this.current_center_y = center_y
+    this.current_anchor_z = anchor_z
+
+    if (this.front_plane_mesh !== null && this.back_plane_mesh !== null) {
+      this.front_plane_mesh.position.set(0, center_y, anchor_z + plane_z)
+      this.back_plane_mesh.position.set(0, center_y, anchor_z - plane_z)
+    }
+  }
+
+  public is_plane_visible (): boolean {
+    return this.is_visible
+  }
+
+  /**
+   * Remove both planes from the scene and dispose their resources
+   */
+  public remove_planes (): void {
+    if (this.plane_group !== null && this.scene_ref !== null) {
+      [this.front_plane_mesh, this.back_plane_mesh].forEach((plane_mesh) => {
+        if (plane_mesh === null) return
+        plane_mesh.geometry.dispose()
+        if (plane_mesh.material instanceof MeshBasicMaterial) {
+          plane_mesh.material.dispose()
+        }
+      })
+
+      this.scene_ref.remove(this.plane_group)
+    }
+
+    this.plane_group = null
+    this.front_plane_mesh = null
+    this.back_plane_mesh = null
+    this.is_visible = false
+  }
+
+  /**
+   * Clean up all resources and reset state
+   */
+  public cleanup (): void {
+    this.remove_planes()
+    this.scene_ref = null
+    this.current_plane_z = 0.0
+    this.current_center_y = 0.0
+    this.current_anchor_z = 0.0
+    this.is_visible = false
+  }
+
+  /**
+   * Build the two planes at the currently stored position
+   */
+  private add_planes (): void {
+    if (this.scene_ref === null) {
+      throw new Error('DepthPlaneManager not initialized with scene reference')
+    }
+
+    this.remove_planes()
+
+    this.plane_group = new Group()
+    this.plane_group.name = this.depth_plane_group_name
+
+    this.front_plane_mesh = this.create_plane_mesh('depth_plane_front')
+    this.back_plane_mesh = this.create_plane_mesh('depth_plane_back')
+
+    this.plane_group.add(this.front_plane_mesh)
+    this.plane_group.add(this.back_plane_mesh)
+    this.scene_ref.add(this.plane_group)
+
+    this.is_visible = true
+
+    // apply the stored position to the freshly created meshes
+    this.update_position(this.current_plane_z, this.current_center_y, this.current_anchor_z)
+  }
+
+  private create_plane_mesh (name: string): Mesh {
+    const geometry = new PlaneGeometry(this.plane_size, this.plane_size)
+    const material = new MeshBasicMaterial({
+      color: 0xff9933, // orange, to distinguish from the green head and blue arm planes
+      transparent: true,
+      opacity: 0.5,
+      side: DoubleSide,
+      wireframe: false
+    })
+
+    const plane_mesh = new Mesh(geometry, material)
+    plane_mesh.name = name
+
+    // PlaneGeometry already faces along Z, so no rotation is needed here
+
+    return plane_mesh
+  }
+}

--- a/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
+++ b/src/lib/processes/edit-skeleton/StepEditSkeleton.ts
@@ -4,7 +4,9 @@ import { Utility } from '../../Utilities.ts'
 import { UndoRedoSystem } from './UndoRedoSystem.ts'
 import { PreviewPlaneManager } from './PreviewPlaneManager.ts'
 import { ArmPlaneManager } from './ArmPlaneManager.ts'
+import { DepthPlaneManager } from './DepthPlaneManager.ts'
 import { ArmWeightCorrector } from '../../solvers/ArmWeightCorrector.ts'
+import { DepthWeightCorrector } from '../../solvers/DepthWeightCorrector.ts'
 import { IndependentBoneMovement } from './IndependentBoneMovement.ts'
 import { ModalDialog } from '../../ModalDialog.ts'
 import {
@@ -60,11 +62,17 @@ export class StepEditSkeleton extends EventTarget {
   private enable_arm_plane_correction: boolean = false
   private arm_plane_offset: number = 0.0
 
+  // Front/back plane state. The distance is measured out from the shoulder
+  // joint's Z, so it has to match the default in create.html's slider.
+  private enable_depth_plane_correction: boolean = false
+  private depth_plane_distance: number = 0.10
+
   private readonly joint_texture = new TextureLoader().load('/images/skeleton-joint-point.png')
 
   private _added_event_listeners: boolean = false
   private readonly preview_plane_manager: PreviewPlaneManager = PreviewPlaneManager.getInstance()
   private readonly arm_plane_manager: ArmPlaneManager = new ArmPlaneManager()
+  private readonly depth_plane_manager: DepthPlaneManager = new DepthPlaneManager()
   public readonly independent_bone_movement: IndependentBoneMovement = new IndependentBoneMovement()
 
   // UI elements specific for this area
@@ -135,11 +143,23 @@ export class StepEditSkeleton extends EventTarget {
       }
     }
 
+    // the front/back correction hands weight back to the spine and head, so it
+    // only makes sense on the human rig too
+    if (this.ui.dom_use_depth_plane_container != null) {
+      if (skeleton_type === SkeletonType.Human) {
+        this.ui.dom_use_depth_plane_container.style.display = 'block'
+      } else {
+        this.ui.dom_use_depth_plane_container.style.display = 'none'
+        this.enable_depth_plane_correction = false // force setting to false in case it was enabled before
+      }
+    }
+
     this.update_skeleton_template_image(skeleton_type)
 
     // show/hide settings for the head correct depending on if it is checked
     this.show_preview_plane_options()
     this.show_arm_plane_options()
+    this.show_depth_plane_options()
   }
 
   private update_skeleton_template_image(skeleton_type: SkeletonType): void {
@@ -224,6 +244,7 @@ export class StepEditSkeleton extends EventTarget {
 
     this.initialize_preview_plane(main_scene)
     this.initialize_arm_plane(main_scene)
+    this.initialize_depth_plane(main_scene)
   }
 
   private initialize_arm_plane (main_scene: Scene): void {
@@ -273,6 +294,54 @@ export class StepEditSkeleton extends EventTarget {
       : Utility.world_position_from_object(shoulder_bone)
 
     this.arm_plane_manager.update_position(anchor_x + this.arm_plane_offset, shoulder_position.y, shoulder_position.z)
+  }
+
+  private initialize_depth_plane (main_scene: Scene): void {
+    this.depth_plane_manager.initialize(main_scene)
+
+    // off by default, but can be enabled if we navigate back to the step
+    this.depth_plane_manager.set_visibility(this.enable_depth_plane_correction)
+    this.refresh_depth_plane_position()
+
+    // set default value (and label) for the plane distance on UI
+    if (this.ui.dom_depth_plane_distance_input !== null && this.ui.dom_depth_plane_distance_label !== null) {
+      this.ui.dom_depth_plane_distance_input.value = this.depth_plane_distance.toString()
+      this.ui.dom_depth_plane_distance_label.textContent = this.format_depth_plane_distance_label()
+    }
+
+    // the checkbox is forced off for non-human rigs, so keep the DOM in sync
+    // with our state instead of leaving a checked box next to a hidden slider
+    if (this.ui.dom_depth_plane_checkbox !== null) {
+      this.ui.dom_depth_plane_checkbox.checked = this.enable_depth_plane_correction
+    }
+  }
+
+  /**
+   * Same percentage formatting as the arm plane offset, since both sliders are
+   * distances in the same small range of scene units.
+   */
+  private format_depth_plane_distance_label (): string {
+    return `${(this.depth_plane_distance * 100).toFixed(1)}%`
+  }
+
+  /**
+   * Move the front and back planes to the shoulder joint's depth, spread apart
+   * by the user's distance. The solver derives its planes the same way at skin
+   * time, so what the user sees here is what actually gets applied.
+   */
+  private refresh_depth_plane_position (): void {
+    const bones = this.threejs_skeleton.bones
+    if (bones.length === 0) { return }
+
+    const anchor_z = DepthWeightCorrector.shoulder_anchor_z(bones)
+    if (anchor_z === null) { return } // no arm bones on this rig
+
+    const shoulder_bone = ArmWeightCorrector.find_shoulder_bone(bones)
+    const shoulder_position = shoulder_bone === undefined
+      ? new Vector3()
+      : Utility.world_position_from_object(shoulder_bone)
+
+    this.depth_plane_manager.update_position(this.depth_plane_distance, shoulder_position.y, anchor_z)
   }
 
   private initialize_preview_plane (main_scene: Scene): void {
@@ -446,6 +515,32 @@ export class StepEditSkeleton extends EventTarget {
     return this.arm_plane_offset
   }
 
+  /**
+   * Toggle the front/back plane correction and the planes that visualize it
+   */
+  public set_use_depth_plane_correction (is_enabled: boolean): void {
+    this.enable_depth_plane_correction = is_enabled
+    this.depth_plane_manager.set_visibility(is_enabled)
+    this.refresh_depth_plane_position()
+  }
+
+  public use_depth_plane_correction (): boolean {
+    return this.enable_depth_plane_correction
+  }
+
+  /**
+   * Set how far in front of and behind the body the planes sit
+   * @param distance Distance along Z measured out from the shoulder joint
+   */
+  public set_depth_plane_distance (distance: number): void {
+    this.depth_plane_distance = distance
+    this.refresh_depth_plane_position()
+  }
+
+  public get_depth_plane_distance (): number {
+    return this.depth_plane_distance
+  }
+
   public add_event_listeners (): void {
     if (this.ui.dom_move_to_origin_button !== null) {
       this.ui.dom_move_to_origin_button.addEventListener('click', () => {
@@ -549,9 +644,29 @@ export class StepEditSkeleton extends EventTarget {
       }
     })
 
-    // keep the arm planes anchored to the shoulder joint when bones get moved
+    // Add front/back plane event listeners
+    this.ui.dom_depth_plane_checkbox?.addEventListener('change', (event) => {
+      const target = event.target as HTMLInputElement
+      this.set_use_depth_plane_correction(target.checked)
+
+      this.show_depth_plane_options()
+    })
+
+    this.ui.dom_depth_plane_distance_input?.addEventListener('input', (event) => {
+      const target = event.target as HTMLInputElement
+      const distance = parseFloat(target.value)
+      this.set_depth_plane_distance(isNaN(distance) ? 0.10 : distance)
+
+      // Update the label to show current value
+      if (this.ui.dom_depth_plane_distance_label !== null) {
+        this.ui.dom_depth_plane_distance_label.textContent = this.format_depth_plane_distance_label()
+      }
+    })
+
+    // keep the arm and depth planes anchored to the shoulder joint when bones get moved
     this.addEventListener('skeletonTransformed', () => {
       this.refresh_arm_plane_position()
+      this.refresh_depth_plane_position()
     })
   }
 
@@ -564,6 +679,12 @@ export class StepEditSkeleton extends EventTarget {
   private show_arm_plane_options (): void {
     if (this.ui.dom_arm_plane_setting_container !== null) {
       this.ui.dom_arm_plane_setting_container.style.display = this.use_arm_plane_correction() ? 'flex' : 'none'
+    }
+  }
+
+  private show_depth_plane_options (): void {
+    if (this.ui.dom_depth_plane_setting_container !== null) {
+      this.ui.dom_depth_plane_setting_container.style.display = this.use_depth_plane_correction() ? 'flex' : 'none'
     }
   }
 
@@ -626,6 +747,15 @@ export class StepEditSkeleton extends EventTarget {
     if (this.ui.dom_arm_plane_offset_input !== null) {
       this.ui.dom_arm_plane_offset_input.removeEventListener('input', () => {})
     }
+
+    // Remove front/back plane event listeners
+    if (this.ui.dom_depth_plane_checkbox !== null) {
+      this.ui.dom_depth_plane_checkbox.removeEventListener('change', () => {})
+    }
+
+    if (this.ui.dom_depth_plane_distance_input !== null) {
+      this.ui.dom_depth_plane_distance_input.removeEventListener('input', () => {})
+    }
   }
 
   public cleanup_on_exit_step (): void {
@@ -633,6 +763,7 @@ export class StepEditSkeleton extends EventTarget {
     this.clear_hover_point_if_exists()
     this.remove_preview_plane()
     this.arm_plane_manager.cleanup()
+    this.depth_plane_manager.cleanup()
   }
 
   /**

--- a/src/lib/processes/weight-skin/StepWeightSkin.ts
+++ b/src/lib/processes/weight-skin/StepWeightSkin.ts
@@ -161,6 +161,17 @@ export class StepWeightSkin extends EventTarget {
     this.bone_skinning_formula.set_arm_plane_offset(offset)
   }
 
+  /**
+   * Configure front/back plane correction settings for the solver
+   * @param enabled Whether front/back plane correction is enabled
+   * @param distance How far either side of the shoulder joint's Z the planes sit
+   */
+  public set_depth_plane_correction_settings (enabled: boolean, distance: number): void {
+    if (this.bone_skinning_formula === undefined) return
+    this.bone_skinning_formula.set_depth_plane_correction_enabled(enabled)
+    this.bone_skinning_formula.set_depth_plane_distance(distance)
+  }
+
   public calculate_weights (): number[][] {
     if (this.bone_skinning_formula === undefined) return [[], []]
     return this.bone_skinning_formula.calculate_indexes_and_weights()

--- a/src/lib/solvers/ArmWeightCorrector.ts
+++ b/src/lib/solvers/ArmWeightCorrector.ts
@@ -1,10 +1,10 @@
 import {
-  Vector3,
-  Bone,
+  type Bone,
   type BufferGeometry
 } from 'three'
 
 import { Utility } from '../Utilities.js'
+import { ArmWeightTransfer } from './ArmWeightTransfer.js'
 
 /**
  * Pulls torso vertices back off the arm bones.
@@ -22,6 +22,9 @@ import { Utility } from '../Utilities.js'
  * The "arm" set is the upperarm bone and everything below it. The clavicle is
  * deliberately excluded — it sits inboard of the shoulder joint and legitimately
  * covers part of the chest.
+ *
+ * See {@link DepthWeightCorrector} for the front/back counterpart, which catches
+ * hair and clothing instead of torso.
  */
 export class ArmWeightCorrector {
   private readonly geometry: BufferGeometry
@@ -80,152 +83,21 @@ export class ArmWeightCorrector {
     const plane_x = anchor_x + this.arm_plane_offset
     if (plane_x <= 0) { return } // plane pushed past the center line, would strip both arms entirely
 
-    const arm_bone_indices = this.find_arm_bone_indices()
+    const arm_bone_indices = ArmWeightTransfer.find_arm_bone_indices(this.bones)
     if (arm_bone_indices.size === 0) { return }
 
-    const fallback_bones = this.build_fallback_bone_candidates(arm_bone_indices)
+    const fallback_bones = ArmWeightTransfer.build_fallback_bone_candidates(this.bones, arm_bone_indices)
     if (fallback_bones.length === 0) { return }
 
-    this.correct_vertex_weights(skin_indices, skin_weights, plane_x, arm_bone_indices, fallback_bones)
-  }
-
-  /**
-   * Every upperarm bone plus all of its descendants (lowerarm, hand, fingers),
-   * on both sides. Walking the hierarchy rather than matching a keyword list
-   * gives exactly "upperarm and below" without needing to enumerate every
-   * finger bone name, and it leaves the clavicle alone.
-   */
-  private find_arm_bone_indices (): Set<number> {
-    const bone_to_index = new Map<Bone, number>()
-    this.bones.forEach((bone, idx) => bone_to_index.set(bone, idx))
-
-    const arm_bone_indices = new Set<number>()
-
-    this.bones.forEach((bone) => {
-      if (!bone.name.toLowerCase().includes('upperarm')) { return }
-
-      bone.traverse((descendant) => {
-        if (!(descendant instanceof Bone)) { return }
-        const index = bone_to_index.get(descendant)
-        if (index !== undefined) {
-          arm_bone_indices.add(index)
-        }
-      })
-    })
-
-    return arm_bone_indices
-  }
-
-  /**
-   * Bones a stripped vertex can be handed to: everything that isn't an arm bone,
-   * minus the root (global transform only) and leaf/orientation bones, which the
-   * solver never assigns vertices to.
-   */
-  private build_fallback_bone_candidates (arm_bone_indices: Set<number>): Array<{ index: number, midpoint: Vector3 }> {
-    const candidates: Array<{ index: number, midpoint: Vector3 }> = []
-
-    this.bones.forEach((bone, idx) => {
-      if (arm_bone_indices.has(idx)) { return }
-      if (bone.name === 'root' || Utility.is_leaf_bone(bone)) { return }
-      candidates.push({ index: idx, midpoint: Utility.bone_midpoint_to_child(bone) })
-    })
-
-    return candidates
-  }
-
-  private correct_vertex_weights (
-    skin_indices: number[],
-    skin_weights: number[],
-    plane_x: number,
-    arm_bone_indices: Set<number>,
-    fallback_bones: Array<{ index: number, midpoint: Vector3 }>
-  ): void {
-    const vertex_count = this.geometry.attributes.position.array.length / 3
-
-    for (let i = 0; i < vertex_count; i++) {
-      const vertex_position = new Vector3().fromBufferAttribute(this.geometry.attributes.position, i)
-
+    ArmWeightTransfer.strip_arm_weights(
+      this.geometry,
+      skin_indices,
+      skin_weights,
+      arm_bone_indices,
+      fallback_bones,
       // Math.abs is what makes this symmetric: one slider drives both arms,
       // regardless of which side of the model is +X.
-      if (Math.abs(vertex_position.x) >= plane_x) { continue } // outboard of the plane, genuinely arm territory
-
-      const offset = i * 4
-
-      // Take the weight away from every arm bone influencing this vertex.
-      // Index 0 is the root bone, which never receives weights, so it doubles
-      // as the "empty slot" marker (same convention as HeadWeightCorrector).
-      let stolen_weight = 0
-      let first_freed_slot = -1
-      for (let j = 0; j < 4; j++) {
-        if (!arm_bone_indices.has(skin_indices[offset + j])) { continue }
-        if (skin_weights[offset + j] <= 0) { continue }
-
-        stolen_weight += skin_weights[offset + j]
-        skin_weights[offset + j] = 0
-        skin_indices[offset + j] = 0
-        if (first_freed_slot === -1) {
-          first_freed_slot = j
-        }
-      }
-
-      if (stolen_weight <= 0) { continue }
-
-      const replacement_bone_index = this.find_closest_fallback_bone(vertex_position, fallback_bones)
-
-      // Merge into the replacement bone's existing slot if it already influences
-      // this vertex, otherwise reuse one of the slots we just emptied.
-      let target_slot = -1
-      for (let j = 0; j < 4; j++) {
-        if (skin_indices[offset + j] === replacement_bone_index && skin_weights[offset + j] > 0) {
-          target_slot = j
-          break
-        }
-      }
-
-      if (target_slot === -1) {
-        target_slot = first_freed_slot
-        skin_indices[offset + target_slot] = replacement_bone_index
-      }
-
-      skin_weights[offset + target_slot] += stolen_weight
-
-      this.normalize_vertex_weights(skin_weights, offset)
-    }
-  }
-
-  private find_closest_fallback_bone (
-    vertex_position: Vector3,
-    fallback_bones: Array<{ index: number, midpoint: Vector3 }>
-  ): number {
-    let closest_distance = Infinity
-    let closest_index = fallback_bones[0].index
-
-    for (const candidate of fallback_bones) {
-      const distance = candidate.midpoint.distanceTo(vertex_position)
-      if (distance < closest_distance) {
-        closest_distance = distance
-        closest_index = candidate.index
-      }
-    }
-
-    return closest_index
-  }
-
-  /**
-   * Normalize weights for a single vertex to ensure they sum to 1.0
-   */
-  private normalize_vertex_weights (skin_weights: number[], offset: number): void {
-    const total_weight =
-      skin_weights[offset] +
-      skin_weights[offset + 1] +
-      skin_weights[offset + 2] +
-      skin_weights[offset + 3]
-
-    if (total_weight > 0) {
-      skin_weights[offset] /= total_weight
-      skin_weights[offset + 1] /= total_weight
-      skin_weights[offset + 2] /= total_weight
-      skin_weights[offset + 3] /= total_weight
-    }
+      (vertex_position) => Math.abs(vertex_position.x) < plane_x
+    )
   }
 }

--- a/src/lib/solvers/ArmWeightTransfer.ts
+++ b/src/lib/solvers/ArmWeightTransfer.ts
@@ -1,0 +1,164 @@
+import { Vector3, Bone, type BufferGeometry } from 'three'
+
+import { Utility } from '../Utilities.js'
+
+/** A bone a stripped vertex can be handed to, with the point distance is measured from. */
+export interface FallbackBone {
+  index: number
+  midpoint: Vector3
+}
+
+/**
+ * The machinery shared by the plane-based arm corrections.
+ *
+ * Both {@link ArmWeightCorrector} and {@link DepthWeightCorrector} do the same
+ * thing - take weight away from arm bones on vertices that are not really arm,
+ * and hand it to the nearest bone that is not part of an arm. They differ only
+ * in which side of a plane counts as "not really arm", so that predicate is the
+ * one thing passed in.
+ */
+export class ArmWeightTransfer {
+  /**
+   * Every upperarm bone plus all of its descendants (lowerarm, hand, fingers),
+   * on both sides. Walking the hierarchy rather than matching a keyword list
+   * gives exactly "upperarm and below" without needing to enumerate every
+   * finger bone name, and it leaves the clavicle alone.
+   */
+  public static find_arm_bone_indices (bones: Bone[]): Set<number> {
+    const bone_to_index = new Map<Bone, number>()
+    bones.forEach((bone, idx) => bone_to_index.set(bone, idx))
+
+    const arm_bone_indices = new Set<number>()
+
+    bones.forEach((bone) => {
+      if (!bone.name.toLowerCase().includes('upperarm')) { return }
+
+      bone.traverse((descendant) => {
+        if (!(descendant instanceof Bone)) { return }
+        const index = bone_to_index.get(descendant)
+        if (index !== undefined) {
+          arm_bone_indices.add(index)
+        }
+      })
+    })
+
+    return arm_bone_indices
+  }
+
+  /**
+   * Bones a stripped vertex can be handed to: everything that isn't an arm bone,
+   * minus the root (global transform only) and leaf/orientation bones, which the
+   * solver never assigns vertices to.
+   */
+  public static build_fallback_bone_candidates (bones: Bone[], arm_bone_indices: Set<number>): FallbackBone[] {
+    const candidates: FallbackBone[] = []
+
+    bones.forEach((bone, idx) => {
+      if (arm_bone_indices.has(idx)) { return }
+      if (bone.name === 'root' || Utility.is_leaf_bone(bone)) { return }
+      candidates.push({ index: idx, midpoint: Utility.bone_midpoint_to_child(bone) })
+    })
+
+    return candidates
+  }
+
+  /**
+   * Takes arm-bone weight off every vertex the predicate selects and gives it to
+   * that vertex's nearest fallback bone. Modifies skin_indices and skin_weights
+   * in place.
+   *
+   * @param is_outside_arm_territory decides, from a vertex's position, whether it
+   * should have been given to an arm bone at all
+   */
+  public static strip_arm_weights (
+    geometry: BufferGeometry,
+    skin_indices: number[],
+    skin_weights: number[],
+    arm_bone_indices: Set<number>,
+    fallback_bones: FallbackBone[],
+    is_outside_arm_territory: (vertex_position: Vector3) => boolean
+  ): void {
+    const vertex_count = geometry.attributes.position.array.length / 3
+
+    for (let i = 0; i < vertex_count; i++) {
+      const vertex_position = new Vector3().fromBufferAttribute(geometry.attributes.position, i)
+
+      if (!is_outside_arm_territory(vertex_position)) { continue } // genuinely arm territory
+
+      const offset = i * 4
+
+      // Take the weight away from every arm bone influencing this vertex.
+      // Index 0 is the root bone, which never receives weights, so it doubles
+      // as the "empty slot" marker (same convention as HeadWeightCorrector).
+      let stolen_weight = 0
+      let first_freed_slot = -1
+      for (let j = 0; j < 4; j++) {
+        if (!arm_bone_indices.has(skin_indices[offset + j])) { continue }
+        if (skin_weights[offset + j] <= 0) { continue }
+
+        stolen_weight += skin_weights[offset + j]
+        skin_weights[offset + j] = 0
+        skin_indices[offset + j] = 0
+        if (first_freed_slot === -1) {
+          first_freed_slot = j
+        }
+      }
+
+      if (stolen_weight <= 0) { continue }
+
+      const replacement_bone_index = this.find_closest_fallback_bone(vertex_position, fallback_bones)
+
+      // Merge into the replacement bone's existing slot if it already influences
+      // this vertex, otherwise reuse one of the slots we just emptied.
+      let target_slot = -1
+      for (let j = 0; j < 4; j++) {
+        if (skin_indices[offset + j] === replacement_bone_index && skin_weights[offset + j] > 0) {
+          target_slot = j
+          break
+        }
+      }
+
+      if (target_slot === -1) {
+        target_slot = first_freed_slot
+        skin_indices[offset + target_slot] = replacement_bone_index
+      }
+
+      skin_weights[offset + target_slot] += stolen_weight
+
+      this.normalize_vertex_weights(skin_weights, offset)
+    }
+  }
+
+  private static find_closest_fallback_bone (vertex_position: Vector3, fallback_bones: FallbackBone[]): number {
+    let closest_distance = Infinity
+    let closest_index = fallback_bones[0].index
+
+    for (const candidate of fallback_bones) {
+      const distance = candidate.midpoint.distanceTo(vertex_position)
+      if (distance < closest_distance) {
+        closest_distance = distance
+        closest_index = candidate.index
+      }
+    }
+
+    return closest_index
+  }
+
+  /**
+   * Normalize weights for a single vertex to ensure they sum to 1.0
+   */
+  public static normalize_vertex_weights (skin_weights: number[], offset: number): void {
+    const total_weight =
+      skin_weights[offset] +
+      skin_weights[offset + 1] +
+      skin_weights[offset + 2] +
+      skin_weights[offset + 3]
+
+    if (total_weight > 0) {
+      skin_weights[offset] /= total_weight
+      skin_weights[offset + 1] /= total_weight
+      skin_weights[offset + 2] /= total_weight
+      skin_weights[offset + 3] /= total_weight
+    }
+  }
+}

--- a/src/lib/solvers/DepthWeightCorrector.test.ts
+++ b/src/lib/solvers/DepthWeightCorrector.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest'
+import { Bone, BufferGeometry, Float32BufferAttribute } from 'three'
+import { DepthWeightCorrector } from './DepthWeightCorrector'
+
+/**
+ * The same minimal humanoid rig the arm plane tests use, with a head and neck
+ * added so there is somewhere sensible for stripped hair weights to land.
+ * WORLD positions:
+ *
+ *   root     (0, 0,   0)
+ *   spine_01 (0, 1.0, 0)   chest (0, 1.5, 0)
+ *   neck     (0, 1.7, 0)   head  (0, 1.9, 0)
+ *   clavicle (+/-0.1, 1.5, 0)   upperarm (+/-1.0, 1.5, 0)
+ *   lowerarm (+/-2.0, 1.5, 0)   hand (+/-3.0, 1.5, 0)
+ *
+ * Every bone sits at z = 0, so the shoulder anchor depth is 0 and the front and
+ * back planes land at +distance and -distance.
+ */
+function build_test_rig (): Bone[] {
+  const root = new Bone()
+  root.name = 'root'
+
+  const spine = new Bone()
+  spine.name = 'spine_01'
+  spine.position.set(0, 1.0, 0)
+  root.add(spine)
+
+  const chest = new Bone()
+  chest.name = 'chest'
+  chest.position.set(0, 0.5, 0)
+  spine.add(chest)
+
+  const neck = new Bone()
+  neck.name = 'neck'
+  neck.position.set(0, 0.2, 0)
+  chest.add(neck)
+
+  const head = new Bone()
+  head.name = 'head'
+  head.position.set(0, 0.2, 0)
+  neck.add(head)
+
+  const head_end = new Bone()
+  head_end.name = 'head_end'
+  head_end.position.set(0, 0.2, 0)
+  head.add(head_end)
+
+  const bones: Bone[] = [root, spine, chest, neck, head, head_end]
+
+  const build_arm = (side: string, direction: number): void => {
+    const clavicle = new Bone()
+    clavicle.name = `clavicle_${side}`
+    clavicle.position.set(direction * 0.1, 0, 0)
+
+    const upperarm = new Bone()
+    upperarm.name = `upperarm_${side}`
+    upperarm.position.set(direction * 0.9, 0, 0)
+
+    const lowerarm = new Bone()
+    lowerarm.name = `lowerarm_${side}`
+    lowerarm.position.set(direction * 1.0, 0, 0)
+
+    const hand = new Bone()
+    hand.name = `hand_${side}`
+    hand.position.set(direction * 1.0, 0, 0)
+
+    lowerarm.add(hand)
+    upperarm.add(lowerarm)
+    clavicle.add(upperarm)
+    chest.add(clavicle)
+
+    bones.push(clavicle, upperarm, lowerarm, hand)
+  }
+
+  build_arm('l', 1)
+  build_arm('r', -1)
+
+  root.updateWorldMatrix(true, true)
+  return bones
+}
+
+function bone_index (bones: Bone[], name: string): number {
+  return bones.findIndex(bone => bone.name === name)
+}
+
+function geometry_from_points (points: Array<[number, number, number]>): BufferGeometry {
+  const geometry = new BufferGeometry()
+  geometry.setAttribute('position', new Float32BufferAttribute(points.flat(), 3))
+  return geometry
+}
+
+describe('DepthWeightCorrector.shoulder_anchor_z', () => {
+  it('returns the world Z of the shoulder joint', () => {
+    const bones = build_test_rig()
+    expect(DepthWeightCorrector.shoulder_anchor_z(bones)).toBeCloseTo(0)
+  })
+
+  it('follows a shoulder that is not at the origin depth', () => {
+    const bones = build_test_rig()
+    const chest = bones[bone_index(bones, 'chest')]
+    chest.position.z = 0.3
+    chest.updateWorldMatrix(true, true)
+
+    expect(DepthWeightCorrector.shoulder_anchor_z(bones)).toBeCloseTo(0.3)
+  })
+
+  it('returns null when the rig has no arm bones', () => {
+    const snake_head = new Bone()
+    snake_head.name = 'head'
+    expect(DepthWeightCorrector.shoulder_anchor_z([snake_head])).toBeNull()
+  })
+})
+
+describe('DepthWeightCorrector.apply_depth_weight_correction', () => {
+  it('takes back hair off an arm bone and hands it to the nearest non-arm bone', () => {
+    const bones = build_test_rig()
+    const upperarm_l = bone_index(bones, 'upperarm_l')
+
+    // a strand hanging behind the shoulder, at the same X and height as the arm
+    const geometry = geometry_from_points([[0.9, 1.5, -0.4]])
+    const skin_indices = [upperarm_l, 0, 0, 0]
+    const skin_weights = [1.0, 0, 0, 0]
+
+    new DepthWeightCorrector(geometry, bones, 0.15).apply_depth_weight_correction(skin_indices, skin_weights)
+
+    expect(skin_indices[0]).not.toBe(upperarm_l)
+    expect(bones[skin_indices[0]].name.includes('arm')).toBe(false)
+    expect(skin_weights[0] + skin_weights[1] + skin_weights[2] + skin_weights[3]).toBeCloseTo(1.0)
+  })
+
+  it('catches hair in front of the body too', () => {
+    const bones = build_test_rig()
+    const upperarm_r = bone_index(bones, 'upperarm_r')
+
+    const geometry = geometry_from_points([[-0.9, 1.5, 0.4]])
+    const skin_indices = [upperarm_r, 0, 0, 0]
+    const skin_weights = [1.0, 0, 0, 0]
+
+    new DepthWeightCorrector(geometry, bones, 0.15).apply_depth_weight_correction(skin_indices, skin_weights)
+
+    expect(bones[skin_indices[0]].name.includes('arm')).toBe(false)
+  })
+
+  it('leaves the arm itself alone, which sits between the two planes', () => {
+    const bones = build_test_rig()
+    const lowerarm_l = bone_index(bones, 'lowerarm_l')
+
+    // out at the wrist but at body depth, which is what the arm plane guards
+    const geometry = geometry_from_points([[2.0, 1.5, 0.05]])
+    const skin_indices = [lowerarm_l, 0, 0, 0]
+    const skin_weights = [1.0, 0, 0, 0]
+
+    new DepthWeightCorrector(geometry, bones, 0.15).apply_depth_weight_correction(skin_indices, skin_weights)
+
+    expect(skin_indices[0]).toBe(lowerarm_l)
+    expect(skin_weights[0]).toBe(1.0)
+  })
+
+  it('measures depth from the shoulder rather than from the world origin', () => {
+    const bones = build_test_rig()
+    const chest = bones[bone_index(bones, 'chest')]
+    chest.position.z = 0.5
+    chest.updateWorldMatrix(true, true)
+
+    const upperarm_l = bone_index(bones, 'upperarm_l')
+
+    // z = 0.55 is far from the origin but only 0.05 off the shoulder's depth
+    const geometry = geometry_from_points([[0.9, 1.5, 0.55]])
+    const skin_indices = [upperarm_l, 0, 0, 0]
+    const skin_weights = [1.0, 0, 0, 0]
+
+    new DepthWeightCorrector(geometry, bones, 0.15).apply_depth_weight_correction(skin_indices, skin_weights)
+
+    expect(skin_indices[0]).toBe(upperarm_l)
+  })
+
+  it('does not touch weights that were never on an arm bone', () => {
+    const bones = build_test_rig()
+    const head = bone_index(bones, 'head')
+
+    const geometry = geometry_from_points([[0.9, 1.5, -0.4]])
+    const skin_indices = [head, 0, 0, 0]
+    const skin_weights = [1.0, 0, 0, 0]
+
+    new DepthWeightCorrector(geometry, bones, 0.15).apply_depth_weight_correction(skin_indices, skin_weights)
+
+    expect(skin_indices[0]).toBe(head)
+    expect(skin_weights[0]).toBe(1.0)
+  })
+
+  it('is a no-op at zero distance, which would otherwise strip both arms entirely', () => {
+    const bones = build_test_rig()
+    const upperarm_l = bone_index(bones, 'upperarm_l')
+
+    const geometry = geometry_from_points([[0.9, 1.5, -0.4]])
+    const skin_indices = [upperarm_l, 0, 0, 0]
+    const skin_weights = [1.0, 0, 0, 0]
+
+    new DepthWeightCorrector(geometry, bones, 0).apply_depth_weight_correction(skin_indices, skin_weights)
+
+    expect(skin_indices[0]).toBe(upperarm_l)
+    expect(skin_weights[0]).toBe(1.0)
+  })
+
+  it('is a no-op when the rig has no arm bones', () => {
+    const snake_head = new Bone()
+    snake_head.name = 'head'
+    snake_head.updateWorldMatrix(true, true)
+
+    const geometry = geometry_from_points([[0, 0, 5]])
+    const skin_indices = [0, 0, 0, 0]
+    const skin_weights = [1.0, 0, 0, 0]
+
+    new DepthWeightCorrector(geometry, [snake_head], 0.15).apply_depth_weight_correction(skin_indices, skin_weights)
+
+    expect(skin_indices).toEqual([0, 0, 0, 0])
+    expect(skin_weights).toEqual([1.0, 0, 0, 0])
+  })
+
+  it('merges the stolen weight into an existing slot for the replacement bone', () => {
+    const bones = build_test_rig()
+    const upperarm_l = bone_index(bones, 'upperarm_l')
+    const chest = bone_index(bones, 'chest')
+
+    const geometry = geometry_from_points([[0.2, 1.5, -0.4]])
+    const skin_indices = [upperarm_l, chest, 0, 0]
+    const skin_weights = [0.6, 0.4, 0, 0]
+
+    new DepthWeightCorrector(geometry, bones, 0.15).apply_depth_weight_correction(skin_indices, skin_weights)
+
+    expect(skin_indices[1]).toBe(chest)
+    expect(skin_weights[1]).toBeCloseTo(1.0)
+    expect(skin_weights[0]).toBe(0)
+  })
+})

--- a/src/lib/solvers/DepthWeightCorrector.ts
+++ b/src/lib/solvers/DepthWeightCorrector.ts
@@ -1,0 +1,88 @@
+import {
+  type Bone,
+  type BufferGeometry
+} from 'three'
+
+import { Utility } from '../Utilities.js'
+import { ArmWeightCorrector } from './ArmWeightCorrector.js'
+import { ArmWeightTransfer } from './ArmWeightTransfer.js'
+
+/**
+ * Pulls hair (and anything else standing off the front or back of the body) off
+ * the arm bones.
+ *
+ * The closest-midpoint pass measures straight-line distance, so a ponytail
+ * hanging down the back or long bangs down the chest can end up nearer to an
+ * upperarm bone than to any spine bone. Raising the arm then drags the hair
+ * along with it.
+ *
+ * {@link ArmWeightCorrector} does not catch this: the hair hangs at roughly the
+ * same X as the arm, so it is outboard of the arm plane and reads as genuine arm
+ * territory. What separates the two is *depth* - arms hang beside the ribcage at
+ * about the same Z as the spine, while the hair sits well in front of or behind
+ * it. So this puts a pair of planes at a fixed distance either side of the
+ * shoulder joint's Z, and any vertex beyond them that was given to an arm bone
+ * has that weight taken away and handed to its nearest non-arm bone.
+ *
+ * That nearest non-arm bone is the head or neck for hair around the shoulders,
+ * and a spine bone for hair that reaches further down - which is how hair
+ * without its own bones is usually weighted by hand anyway.
+ */
+export class DepthWeightCorrector {
+  private readonly geometry: BufferGeometry
+  private readonly bones: Bone[]
+  private readonly depth_plane_distance: number
+
+  constructor (geometry: BufferGeometry, bones_master_data: Bone[], depth_plane_distance: number) {
+    this.geometry = geometry
+    this.bones = bones_master_data
+    this.depth_plane_distance = depth_plane_distance
+  }
+
+  /**
+   * The depth the front and back planes are measured out from, which is the
+   * shoulder joint's Z - the depth the arms actually hang at.
+   *
+   * Shared with the edit-skeleton preview so the planes the user sees and the
+   * planes the solver uses are derived the same way, exactly as
+   * {@link ArmWeightCorrector.shoulder_anchor_x} is for the arm plane.
+   *
+   * @returns the world Z of the shoulder joint, or null if no arm bone was found
+   */
+  public static shoulder_anchor_z (bones: Bone[]): number | null {
+    const shoulder_bone = ArmWeightCorrector.find_shoulder_bone(bones)
+    if (shoulder_bone === undefined) {
+      return null
+    }
+    return Utility.world_position_from_object(shoulder_bone).z
+  }
+
+  /**
+   * Reassign arm-bone weights on vertices in front of the front plane or behind
+   * the back plane. Modifies skin_indices and skin_weights in place. Runs before
+   * smoothing so the smoother blends the new boundary instead of leaving a seam.
+   */
+  public apply_depth_weight_correction (skin_indices: number[], skin_weights: number[]): void {
+    if (this.depth_plane_distance <= 0) { return } // planes collapsed onto the body, would strip both arms entirely
+
+    const anchor_z = DepthWeightCorrector.shoulder_anchor_z(this.bones)
+    if (anchor_z === null) { return } // no arm bones on this rig, nothing to correct
+
+    const arm_bone_indices = ArmWeightTransfer.find_arm_bone_indices(this.bones)
+    if (arm_bone_indices.size === 0) { return }
+
+    const fallback_bones = ArmWeightTransfer.build_fallback_bone_candidates(this.bones, arm_bone_indices)
+    if (fallback_bones.length === 0) { return }
+
+    ArmWeightTransfer.strip_arm_weights(
+      this.geometry,
+      skin_indices,
+      skin_weights,
+      arm_bone_indices,
+      fallback_bones,
+      // One slider drives both planes, so a model with hair on only one side
+      // still gets a symmetric, predictable boundary.
+      (vertex_position) => Math.abs(vertex_position.z - anchor_z) > this.depth_plane_distance
+    )
+  }
+}

--- a/src/lib/solvers/SkinningAlgorithm.ts
+++ b/src/lib/solvers/SkinningAlgorithm.ts
@@ -8,6 +8,7 @@ import { Utility } from '../Utilities.js'
 import { SkeletonType } from '../enums/SkeletonType.js'
 import { HeadWeightCorrector } from './HeadWeightCorrector.js'
 import { ArmWeightCorrector } from './ArmWeightCorrector.js'
+import { DepthWeightCorrector } from './DepthWeightCorrector.js'
 import { WeightCalculator } from './WeightCalculator.js'
 import { ExtremityWeightCorrector } from './ExtremityWeightCorrector.js'
 import { WeightSmoother } from './WeightSmoother.js'
@@ -36,6 +37,11 @@ export default class SkinningAlgorithm {
   private use_arm_plane_correction: boolean = false
   private arm_plane_offset: number = 0.0
 
+  // Front/back plane correction properties. The distance is measured out from
+  // the shoulder joint's Z, which the corrector reads off the bones itself.
+  private use_depth_plane_correction: boolean = false
+  private depth_plane_distance: number = 0.10
+
   constructor (bone_hier: Object3D, skeleton_type: SkeletonType) {
     this.skeleton_type = skeleton_type
     this.bones_master_data = Utility.bone_list_from_hierarchy(bone_hier)
@@ -59,6 +65,14 @@ export default class SkinningAlgorithm {
 
   public set_arm_plane_offset (offset: number): void {
     this.arm_plane_offset = offset
+  }
+
+  public set_depth_plane_correction_enabled (enabled: boolean): void {
+    this.use_depth_plane_correction = enabled
+  }
+
+  public set_depth_plane_distance (distance: number): void {
+    this.depth_plane_distance = distance
   }
 
   public calculate_indexes_and_weights (): number[][] {
@@ -89,6 +103,19 @@ export default class SkinningAlgorithm {
         this.arm_plane_offset
       )
       arm_weight_corrector.apply_arm_weight_correction(skin_indices, skin_weights)
+    }
+
+    // Step 1d: Hand hair and other front/back geometry back from the arm bones.
+    // Long hair hangs at the same height and X as the arms, so the arm plane
+    // above cannot separate them - only depth can. Runs before smoothing for the
+    // same reason the arm correction does.
+    if (this.use_depth_plane_correction) {
+      const depth_weight_corrector = new DepthWeightCorrector(
+        this.geometry,
+        this.bones_master_data,
+        this.depth_plane_distance
+      )
+      depth_weight_corrector.apply_depth_weight_correction(skin_indices, skin_weights)
     }
 
     // Step 2: Smooth weight boundaries between adjacent bones


### PR DESCRIPTION
#149 

### Problem: 
Long hair hangs at roughly the same height and X as the upper arm, so the closest-midpoint pass can hand a ponytail or a chest-length strand to an arm bone. Raising the arm then drags the hair with it.

Neither existing correction catches this. ArmWeightCorrector only strips vertices inboard of the shoulder, and the hair is outboard. HeadWeightCorrector only looks above a height threshold, and the hair reaches well below it. What separates hair from arm is depth: arms hang beside the ribcage at about the same Z as the spine, while the hair sits well in front of or behind it.

### Solution:
DepthWeightCorrector puts a pair of planes at a fixed distance either side of the shoulder joint's Z. Any vertex beyond them that was given to an arm bone has that weight taken away and handed to its nearest non-arm bone, which is the head or neck for hair around the shoulders and a spine bone for hair that reaches further down. It runs before smoothing, like the arm correction, so the smoother blends the new boundary instead of leaving a seam.

The two plane corrections now share their machinery through ArmWeightTransfer - finding the arm bones, building the fallback candidates, moving the weight and renormalising - and differ only in the predicate that decides which side of a plane counts as arm. This replaces what would otherwise have been a third copy of the same code.

Exposed as "Use Front/Back Plane Correction" with a depth slider, alongside the head and arm options, with DepthPlaneManager drawing the two planes so the user can see the cut before applying it. Human rigs only, since the stripped weight goes back to the spine and head.

<img width="820" height="664" alt="Screenshot 2026-09-05 at 7 14 27 PM" src="https://github.com/user-attachments/assets/b65416a8-9707-4738-8d66-1e7baf4883ac" />

### Before opening this pull request

Please discuss the problem and proposed approach in the Mesh2Motion Discord (https://discord.gg/UChE936q7y) before submitting code. This project receives a too many untested changes, so discussion helps me confirm that:

- The problem is real and affects the project or its users.
- The approach is consistent with the existing workflow and project direction.
- The change is small enough to review and maintain.


### When later doing the pull request

Make sure to include these type of details

- **Description on the current problem, and your proposed solution**
- **Steps to reproduce the bug, or use the new feature**


### Checklist before submitting

- [ ] I discussed the problem and proposed approach in Discord.
- [ ] I have provided enough context for someone else to reproduce and review the change.
- [ ] I have kept this pull request focused and removed unrelated changes.
- [ ] I tested the original reproduction steps and confirmed the problem is fixed.
- [ ] I understand that incomplete, untested, or unexplained pull requests may be closed without review.
